### PR TITLE
ci: migrate Homebrew token to Doppler

### DIFF
--- a/.github/workflows/openkakao-rs-release.yml
+++ b/.github/workflows/openkakao-rs-release.yml
@@ -87,6 +87,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     steps:
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Fetch Homebrew token
+        id: doppler
+        run: |
+          TOKEN=$(doppler secrets get HOMEBREW_TAP_TOKEN --plain)
+          echo "::add-mask::$TOKEN"
+          echo "HOMEBREW_TAP_TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -107,7 +119,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: JungHoonGhae/homebrew-openkakao
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.doppler.outputs.HOMEBREW_TAP_TOKEN }}
           path: tap
 
       - name: Update formula


### PR DESCRIPTION
Replace direct HOMEBREW_TAP_TOKEN secret with Doppler service token injection.