### PR TITLE
ci: harden Doppler token fetch

### DIFF
--- a/.github/workflows/openkakao-rs-release.yml
+++ b/.github/workflows/openkakao-rs-release.yml
@@ -93,7 +93,12 @@ jobs:
       - name: Fetch Homebrew token
         id: doppler
         run: |
-          TOKEN=$(doppler secrets get HOMEBREW_TAP_TOKEN --plain)
+          set -euo pipefail
+          TOKEN=$(doppler secrets get HOMEBREW_TAP_TOKEN --plain 2>/dev/null)
+          if [ -z "$TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN not found in Doppler"
+            exit 1
+          fi
           echo "::add-mask::$TOKEN"
           echo "HOMEBREW_TAP_TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Summary
- Add `set -euo pipefail` and stderr suppression (`2>/dev/null`) to prevent token leakage
- Validate fetched HOMEBREW_TAP_TOKEN is non-empty with clear `::error::` message

## Test plan
- [ ] Verify release workflow succeeds on next `openkakao-rs-v*` tag