### PR TITLE
docs: comprehensive website overhaul for v0.7.1

### DIFF
--- a/website/content/docs/automation/common-recipes.mdx
+++ b/website/content/docs/automation/common-recipes.mdx
@@ -18,7 +18,7 @@ Use this only after you are comfortable with the send behavior on your own accou
 ## Recent chat export
 
 ```bash
-openkakao-rs loco-read <chat_id> -n 200 --json > messages.json
+openkakao-rs read <chat_id> -n 200 --json > messages.json
 ```
 
 This is the safest starting point for analysis workflows because it is read-only.
@@ -36,7 +36,7 @@ done
 ## Structured hook trigger
 
 ```bash
-openkakao-rs watch \
+openkakao-rs --unattended --allow-watch-side-effects watch \
   --hook-cmd 'jq . > /tmp/openkakao-last-event.json' \
   --hook-chat-id <chat_id> \
   --hook-keyword urgent \
@@ -48,7 +48,7 @@ This keeps the first automation step local. A shell script can inspect the JSON 
 ## Webhook relay
 
 ```bash
-openkakao-rs watch \
+openkakao-rs --unattended --allow-watch-side-effects watch \
   --webhook-url https://hooks.example.com/openkakao \
   --webhook-header 'Authorization: Bearer token' \
   --webhook-signing-secret 'super-secret' \
@@ -84,7 +84,7 @@ This is the minimum check. In production, also reject stale timestamps.
 ## Local SQLite archive
 
 ```bash
-openkakao-rs loco-read <chat_id> --all --json | jq -c '.[]' > messages.ndjson
+openkakao-rs read <chat_id> --all --json | jq -c '.[]' > messages.ndjson
 sqlite3 chats.db '.mode json' '.import messages.ndjson messages'
 ```
 

--- a/website/content/docs/automation/llm-agent-workflows.mdx
+++ b/website/content/docs/automation/llm-agent-workflows.mdx
@@ -10,7 +10,7 @@ This is a natural fit if you already use terminal-first agent tooling. The impor
 ## Low-risk pattern: local summarization
 
 ```bash
-openkakao-rs loco-read <chat_id> -n 50 --json | \
+openkakao-rs read <chat_id> -n 50 --json | \
   jq -r '.[] | "\(.author): \(.message)"' | \
   llm "Summarize this conversation in 3 bullet points"
 ```

--- a/website/content/docs/automation/watch-patterns.mdx
+++ b/website/content/docs/automation/watch-patterns.mdx
@@ -111,10 +111,28 @@ The signature covers `timestamp.payload` using HMAC-SHA256.
 Receiver checklist:
 
 - require HTTPS
-- validate `X-OpenKakao-Timestamp` against a short time window
+- validate `X-OpenKakao-Timestamp` against a short time window (recommended: reject timestamps older than 5 minutes)
 - recompute `X-OpenKakao-Signature`
 - log delivery failures separately from business logic failures
 - make the receiver idempotent if duplicate events would hurt
+
+### Timestamp Validation
+
+The `X-OpenKakao-Timestamp` header contains the Unix epoch (seconds) when the event was signed. To prevent replay attacks, your receiver should reject requests where the timestamp differs from the server's current time by more than a reasonable window.
+
+A 5-minute window is a practical default. It is wide enough to absorb clock skew and network latency, but narrow enough to reject most replays:
+
+```python
+import time
+
+MAX_AGE_SECONDS = 300  # 5 minutes
+
+def validate_timestamp(header_timestamp: str) -> bool:
+    ts = int(header_timestamp)
+    return abs(time.time() - ts) < MAX_AGE_SECONDS
+```
+
+If your receiver runs on infrastructure with well-synchronized clocks (NTP), you can tighten this to 60 seconds. If clock skew is a concern, keep the 5-minute default and monitor for rejected requests before tightening.
 
 ## Combining Options
 

--- a/website/content/docs/cli/chat.mdx
+++ b/website/content/docs/cli/chat.mdx
@@ -91,6 +91,32 @@ Use `0` as chat_id to find/create MemoChat (chat with yourself).
 
 ---
 
+## MemoChat
+
+MemoChat (나와의 채팅) is your private chat-with-yourself room. It is useful for testing sends, storing notes, and verifying automation pipelines without touching real conversations.
+
+MemoChat does **not** appear in the `LCHATLIST` response from the server. You cannot discover it by running `chats`. Instead, use `chatinfo` with id `0` to find or create it:
+
+```bash
+openkakao-rs chatinfo 0
+```
+
+This issues a LOCO `CREATE` command with `memberIds: []` and `memoChat: true`. If a MemoChat already exists for your account, the server returns its chatId. If not, it creates one.
+
+Once you have the MemoChat chatId, you can use it with `read`, `send`, `watch`, and other chat-scoped commands like any other room:
+
+```bash
+# Read MemoChat messages
+openkakao-rs read <memo_chat_id>
+
+# Send a test message to MemoChat
+openkakao-rs send <memo_chat_id> "test message" -y
+```
+
+MemoChat is the safest target for testing outbound automation before pointing it at real conversations.
+
+---
+
 ## profile (chat-scoped LOCO)
 
 `profile` can point at a specific chat and reuse LOCO `GETMEM`.

--- a/website/content/docs/cli/media.mdx
+++ b/website/content/docs/cli/media.mdx
@@ -32,7 +32,7 @@ Files are saved as `{output_dir}/{chat_id}/{log_id}_{filename}`.
 The `log_id` is shown in JSON output:
 
 ```bash
-openkakao-rs loco-read <chat_id> --json | jq '.[] | select(.type != 1) | {logId, type, message}'
+openkakao-rs read <chat_id> --json | jq '.[] | select(.type != 1) | {logId, type, message}'
 ```
 
 ## Auto-Download

--- a/website/content/docs/cli/message.mdx
+++ b/website/content/docs/cli/message.mdx
@@ -32,6 +32,8 @@ These commands answer a simple question: do you want a cheap cache-backed read, 
 
 Read messages from a chat room. By default this uses LOCO and gives you the more reliable history path.
 
+As of v0.7.1, `read` bootstraps from the LOGINLIST response for faster initial results. When you request a specific chat, the CLI passes that chatId in the LOGINLIST `chatIds`/`maxIds` arrays during connection. The server returns recent messages (including received ones) in the `chatLog` field of the login response. These messages are available immediately, before the first SYNCMSG round-trip. Messages from LOGINLIST are automatically deduplicated against subsequent SYNCMSG results, so you never see duplicates.
+
 ```bash
 openkakao-rs read <chat_id> [OPTIONS]
 ```

--- a/website/content/docs/cli/watch.mdx
+++ b/website/content/docs/cli/watch.mdx
@@ -137,6 +137,29 @@ openkakao-rs watch \
 | Max retries exceeded | Exit |
 | Ctrl-C | Save watch state for `--resume` |
 
+## Watch State and Recovery
+
+When `watch` is interrupted (Ctrl-C or SIGTERM), it persists its position to:
+
+```text
+~/.config/openkakao/watch_state.json
+```
+
+This file records the last processed logId per chat, allowing `--resume` to pick up where the previous session left off without replaying already-seen messages.
+
+Use `--resume` for long-running or restarted watch processes:
+
+```bash
+openkakao-rs watch --resume
+```
+
+Recovery behavior:
+
+- If `watch_state.json` exists and `--resume` is set, the watcher skips messages with logIds at or below the saved watermark.
+- If the file does not exist or `--resume` is not set, the watcher starts fresh from the current position.
+- The state file is shared across process restarts. If you run multiple watch processes, they will overwrite each other's state. Run one watch process per machine.
+- The state file is written atomically on shutdown. If the process is killed with SIGKILL (kill -9), state may not be saved.
+
 <Callout title="Reconnect is transport resilience, not delivery guarantee">
   The socket reconnect ladder helps you stay attached to LOCO. It does not guarantee that every downstream hook or webhook side effect happened exactly once.
 </Callout>

--- a/website/content/docs/getting-started/authentication.mdx
+++ b/website/content/docs/getting-started/authentication.mdx
@@ -68,14 +68,14 @@ Default behavior remains conservative:
 - `auth.prefer_relogin = true`
 - `auth.auto_renew = true`
 
-That means the default order is:
+That means the default credential loading order is:
 
-1. saved credentials
-2. `login.json` relogin
-3. `refresh_token` renewal
-4. fresh Cache.db extraction
+1. **Saved credentials** (`~/.config/openkakao/credentials.json`) -- fastest path, no network call. The CLI checks this first on every invocation.
+2. **`login.json` relogin** -- reconstructs the desktop login flow with X-VC header to get a fresh access_token (~65 chars). Works for both LOCO and REST.
+3. **`refresh_token` renewal** -- uses the cached refresh_token to request a new access_token from renewal endpoints. Lighter than full relogin but depends on the refresh_token still being valid.
+4. **Fresh Cache.db extraction** -- extracts the bearer token from the KakaoTalk macOS app's HTTP cache. This token (~138 chars) only works for REST, not LOCO. This is the last resort.
 
-If you disable `auto_renew`, the renewal step is skipped. If you set `prefer_relogin = false`, renewal is attempted before relogin.
+If you disable `auto_renew`, step 3 (renewal) is skipped. If you set `prefer_relogin = false`, renewal (step 3) is attempted before relogin (step 2).
 If you set `auth.password_cmd`, relogin can source the password from an external command such as Doppler instead of relying only on cached request state.
 
 Do not build unattended jobs that assume recovery will always succeed after upstream client or server changes.
@@ -115,6 +115,7 @@ For persistent setups, move those permissions and auth policy into [Configuratio
 |---|---|---|
 | `-950` | token expired or LOCO login rejected | run relogin, then verify whether renewal should still be enabled |
 | `-300` | device or request mismatch | inspect identifiers, local app state, and login inputs |
+| `-203` | auth failure (wrong memberIds or stale inputs) | re-authenticate from scratch with `login --save` |
 | `-400` | missing parameters | re-run login and validate extracted inputs |
 
 ## Next

--- a/website/content/docs/getting-started/troubleshooting.mdx
+++ b/website/content/docs/getting-started/troubleshooting.mdx
@@ -61,6 +61,27 @@ Check whether you are:
 
 Validate that the affected command still works on a small manual case before putting it back into automation. Media flows are often more fragile than plain text operations.
 
+## LOCO Protocol Error Codes
+
+When a LOCO command fails, the server returns a numeric status code. These are the most common:
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| `0` | Success | Nothing to fix |
+| `-950` | Token expired or wrong token type | Your access token has expired. Run `openkakao-rs relogin --fresh-xvc` to get a fresh token. If you are using a Cache.db REST token (~138 chars) for LOCO commands, that will not work -- LOCO requires the login.json access_token (~65 chars). |
+| `-300` | Device or request mismatch | The device_uuid or userId does not match what the server expects. Verify your local app state matches the logged-in session. Re-run `login --save` to re-extract identifiers. |
+| `-203` | Auth failure | Authentication rejected. Common when memberIds are wrong in a CREATE request, or when login inputs are stale. Re-authenticate from scratch. |
+| `-400` | Missing parameters | A required BSON field is missing from the request. This usually means the local credential extraction is incomplete. Re-run `login --save` and check that `credentials.json` has all expected fields. |
+| `-999` | Server-side rejection | A catch-all server error. Usually not recoverable by retrying. Check for upstream changes. |
+
+Enable debug logging for more detail:
+
+```bash
+OPENKAKAO_RS_DEBUG=1 openkakao-rs read <chat_id>
+```
+
+This prints raw LOCO packet exchanges, which helps identify exactly which command is failing and what the server returned.
+
 ## Good debugging posture
 
 - reduce the command to the smallest failing case

--- a/website/content/docs/overview/changelog.mdx
+++ b/website/content/docs/overview/changelog.mdx
@@ -1,0 +1,25 @@
+---
+title: Changelog
+description: Release notes for OpenKakao.
+---
+
+# Changelog
+
+## v0.7.1
+
+**LOGINLIST chatLog sync for faster reads.**
+
+- `read` now passes the target chatId in the LOGINLIST `chatIds`/`maxIds` arrays during connection. The server returns recent messages (including received ones) in the login response's `chatLog` field, making the initial read faster and more complete.
+- New `sync_chat_ids` field on `LocoClient` (`Vec<(i64, i64)>`) allows commands to request specific chat data from LOGINLIST before the first SYNCMSG round-trip.
+- Messages from LOGINLIST `chatLog` are automatically deduplicated against SYNCMSG results by logId.
+- Cache.db-free auto-relogin via `email_cmd` with 3-tier fallback for credential recovery.
+
+## v0.7.0
+
+**Polish, Error Model, Output Consistency.**
+
+- `OpenKakaoError` adopted across watch, send, read, and loco_helpers paths with `is_retryable()` support for smarter reconnect decisions.
+- Profile module split: `profile.rs` (1784 lines) refactored into a 5-file `profile/` directory (mod.rs, hints.rs, graph.rs, probe.rs, app_state.rs).
+- `--json` output added for `send`, `send-file`, and `watch` (NDJSON streaming).
+- Dead code cleanup: zero `#[allow(dead_code)]` remaining, removed unused variants and functions.
+- All 165+ tests passing, zero clippy warnings.

--- a/website/content/docs/overview/meta.json
+++ b/website/content/docs/overview/meta.json
@@ -6,6 +6,7 @@
   "pages": [
     "---Introduction---",
     "why-openkakao",
-    "limitations"
+    "limitations",
+    "changelog"
   ]
 }

--- a/website/content/docs/protocol/commands.mdx
+++ b/website/content/docs/protocol/commands.mdx
@@ -120,6 +120,30 @@ Returns: `vh` (vhost), `p` (port), `k` (upload key).
 
 After POST, the encrypted file data is sent through the AES-GCM channel.
 
+## Connection
+
+### LOGINLIST — Authenticate and Sync
+
+Sent during login (Step 3 of the connection flow). In addition to authentication, LOGINLIST can request recent messages for specific chats via the `chatIds` and `maxIds` arrays.
+
+**Request fields (sync-related):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `chatIds` | `[i64]` | Chat IDs to request recent messages for |
+| `maxIds` | `[i64]` | Highest known logId per chat (0 = get all recent) |
+
+When `chatIds` is non-empty, the server response includes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `chatDatas` | `[object]` | Per-chat metadata and message log |
+| `chatDatas[].chatLog` | `[object]` | Recent messages for the requested chat |
+
+This is used by the `read` command (v0.7.1+) to bootstrap message history from the login response before issuing SYNCMSG requests. Messages from `chatLog` are deduplicated against SYNCMSG results by logId.
+
+See [Connection Flow](/docs/protocol/connection) for the full LOGINLIST request/response structure.
+
 ## System
 
 ### PING — Keep-Alive

--- a/website/content/docs/protocol/connection.mdx
+++ b/website/content/docs/protocol/connection.mdx
@@ -72,7 +72,9 @@ Connect to the assigned LOCO server with RSA handshake + AES-GCM, then authentic
 }
 ```
 
-**Response:** Status 0 with userId and chat room list.
+When `chatIds` and `maxIds` are populated, the server returns recent messages for those chats in the response. This is used by the `read` command (v0.7.1+) to bootstrap message history directly from the login handshake, avoiding an extra SYNCMSG round-trip for the initial batch.
+
+**Response:** Status 0 with userId, chat room list, and (when requested) per-chat `chatDatas` containing `chatLog` message arrays.
 
 ## Auto-Refresh
 

--- a/website/content/docs/protocol/encryption.mdx
+++ b/website/content/docs/protocol/encryption.mdx
@@ -50,6 +50,17 @@ After the handshake, all data is encrypted with AES-128-GCM:
 
 Each packet and each file upload chunk uses a fresh random nonce to prevent nonce reuse.
 
+## Fragility Warning
+
+The handshake constants (`key_encrypt_type = 16`, `encrypt_type = 3`) are not documented by Kakao and were determined through reverse engineering. These values are fragile:
+
+- **`key_encrypt_type` must be exactly 16 (0x10)**, not 15 (0x0F). The difference is a single bit, and the wrong value causes a silent handshake rejection. This has been a recurring source of confusion in third-party implementations.
+- **`encrypt_type` must be exactly 3** (AES-128-GCM). The server does not negotiate or fall back. Sending 2 (the old CFB mode) results in a rejected connection.
+- **RSA exponent `e = 3`** is unusual (most implementations default to 65537). If your RSA library does not support `e = 3`, the handshake will fail.
+- **SHA-1 for OAEP padding** is required. SHA-256 OAEP will produce a valid-looking ciphertext that the server silently rejects.
+
+These constants can change without notice in a KakaoTalk app update. If connections start failing after an app update, re-extract the RSA public key from the new binary and check whether any handshake constants have changed.
+
 ## Historical Note
 
 Earlier versions of KakaoTalk used `encrypt_type = 2` (AES-128-CFB). The current version uses `encrypt_type = 3` (AES-128-GCM), which provides authenticated encryption.

--- a/website/content/docs/security/safe-usage.mdx
+++ b/website/content/docs/security/safe-usage.mdx
@@ -50,6 +50,24 @@ The safest use of OpenKakao is not maximal automation. It is controlled local au
 
 Open chats are a higher-risk surface. If you are automating sends there, assume the bar for suspicious behavior is lower and use the strongest possible restraint.
 
+## Rate Limiting by Chat Type
+
+Different chat types have different risk profiles and should be treated with different frequency limits:
+
+| Chat type | CLI flag | Recommended behavior |
+|-----------|----------|---------------------|
+| MemoChat (`memo`) | none needed | Safe for frequent testing and automation dry-runs |
+| DM / Group (`dm`, `group`) | default | Normal operation; keep send frequency reasonable (seconds between messages, not milliseconds) |
+| Open chat (`open`) | `--force` required | High ban risk; the CLI enforces a 500ms minimum delay between read batches; keep sends infrequent and purposeful |
+
+For automation loops, build in explicit delays between operations:
+
+- **Reads**: The CLI enforces 500ms minimum delay for open chat SYNCMSG batches. For DM/group chats, the default 100ms `--delay-ms` is reasonable.
+- **Sends**: No built-in rate limiter. Your automation code should enforce its own send interval. A minimum of 2-3 seconds between sends is a safe starting point.
+- **Watch hooks**: Controlled by `safety.min_hook_interval_secs` and `safety.min_webhook_interval_secs` in config.
+
+Open chats require `--force` for LOCO operations precisely because the risk is higher. If your workflow touches open chats, keep the scope as narrow as possible and monitor for any account warnings.
+
 ## Machine Hygiene
 
 <Cards>


### PR DESCRIPTION
## Summary

- **v0.7.1 LOGINLIST chatLog sync**: Documented the new read bootstrapping from LOGINLIST in `cli/message.mdx`, `protocol/commands.mdx`, and `protocol/connection.mdx`
- **Legacy command naming cleanup**: Replaced `loco-read`, `loco-chats` etc. with modern `read`, `chats` in all primary examples across `common-recipes.mdx`, `llm-agent-workflows.mdx`, `media.mdx`
- **Webhook timestamp validation**: Added 5-minute window guidance with code example in `automation/watch-patterns.mdx`
- **MemoChat documentation**: Added full explanation of MemoChat discovery via `chatinfo 0` in `cli/chat.mdx`
- **Rate limiting by chat type**: Added rate limiting table and guidance for memo/DM/group/open chats in `security/safe-usage.mdx`
- **Watch state recovery**: Documented `watch_state.json` persistence and `--resume` behavior in `cli/watch.mdx`
- **LOCO error codes**: Added protocol-level error troubleshooting table (-950, -300, -203, -400, -999) with debug logging in `getting-started/troubleshooting.mdx`
- **Credential loading order**: Clarified the 4-tier fallback chain with token type details in `getting-started/authentication.mdx`
- **Encryption fragility warning**: Added section explaining why handshake constants are fragile in `protocol/encryption.mdx`
- **Changelog**: Created `overview/changelog.mdx` with v0.7.0 and v0.7.1 release notes, added to nav
- **Missing unattended flags**: Fixed watch examples in `common-recipes.mdx` that were missing `--unattended --allow-watch-side-effects`

## Test plan

- [ ] Verify website builds without errors (`npm run build` in website/)
- [ ] Check all new MDX pages render correctly in the browser
- [ ] Verify changelog page appears in the Overview nav section
- [ ] Spot-check code examples for correct CLI syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples throughout documentation (replaced `loco-read` with `read`).
  * Added global flags (`--unattended`, `--allow-watch-side-effects`) to watch command examples.
  * Expanded credential loading order and authentication failure guidance.
  * Documented watch state persistence for recovery via `--resume`.
  * Added MemoChat functionality details and LOCO protocol error codes.
  * Introduced timestamp validation guidance for webhook receivers.
  * Added changelog documenting v0.7.1 and v0.7.0 releases.
  * Enhanced rate-limiting and security recommendations for chat operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->