### PR TITLE
ci: auto-update Homebrew formula sha256 on tag push

### DIFF
--- a/.github/workflows/update-formula-sha.yml
+++ b/.github/workflows/update-formula-sha.yml
@@ -27,10 +27,15 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
-          SHA=$(curl -sL "$URL" | sha256sum | awk '{print $1}')
+          HTTP_CODE=$(curl -sL -o /tmp/source.tar.gz -w '%{http_code}' "$URL")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Tarball download failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+          SHA=$(sha256sum /tmp/source.tar.gz | awk '{print $1}')
           EMPTY_SHA="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           if [ -z "$SHA" ] || [ "$SHA" = "$EMPTY_SHA" ]; then
-            echo "::error::Failed to download tarball or got empty file"
+            echo "::error::Downloaded tarball is empty"
             exit 1
           fi
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- `v*` 태그 push 시 `Formula/openkakao.rb`의 URL과 sha256을 자동으로 업데이트하는 GitHub Actions 워크플로우 추가
- 빈 tarball 다운로드 시 안전하게 실패하도록 empty-SHA 체크 포함
- 모든 GitHub context 값은 `env:`를 통해 전달 (command injection 방지)

## Test plan

- [ ] `v*` 태그 push 후 워크플로우 실행 확인
- [ ] Formula 파일의 URL과 sha256이 올바르게 업데이트되는지 확인
- [ ] 잘못된 태그에서 빈 tarball 체크가 작동하는지 확인