### PR TITLE
feat: new-device passcode verification in login --manual (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-06-27
+
+### Added
+- **`login --manual` now completes KakaoTalk's new-device verification** (#20): when logging in from a Mac the account has never seen, `login.json` returns `status=-100` (device not registered). The CLI now runs the passcode handshake automatically — it asks KakaoTalk to send a passcode (`request_passcode.json`), prompts for the code delivered to your phone / another logged-in device, registers the device (`register_device.json`), and retries the login. First-time logins from a fresh device can now finish without manually approving in the app.
+
+### Changed
+- The `login --manual` failure hint no longer claims new-device verification is unsupported; remaining non-`-999` failures point at the email/phone, password, or passcode.
+
 ## [1.3.1] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ brew install openkakao-cli
 
 # 1. 인증 정보 저장
 #    최신 KakaoTalk은 토큰을 캐시에 남기지 않으므로 이메일+비번 로그인을 권장합니다 (#15)
+#    처음 보는 기기면 KakaoTalk이 인증번호(passcode)를 보내며, CLI가 입력을 받아 기기 등록을 마칩니다 (#20)
 openkakao-cli login --manual --save
 #    (예전 빌드에서 캐시 추출이 되는 경우: openkakao-cli login --save)
 

--- a/docs/research/credential-storage.md
+++ b/docs/research/credential-storage.md
@@ -80,10 +80,13 @@ depend on `Cache.db`:
 working `login --save`) has no UUID and is blocked. Generating it from
 `IOPlatformUUID` closes the gap and makes email+password login fully self-sufficient.
 
-**Caveat:** logging in with a fresh `device_uuid` may trigger Kakao's new-device
-verification (2FA / PASSCODE). That step is not yet handled and would need a
-follow-up. Login itself is a normal auth call (not an unofficial LOCO write), so it
-is not a ban trigger, but repeated logins with a spoofed device should be avoided.
+**New-device verification (handled since v1.3.2, #20):** logging in with a fresh
+`device_uuid` makes `login.json` return `status=-100` (DEVICE_NOT_REGISTERED). The
+`--manual` flow now completes the passcode handshake automatically:
+`request_passcode.json` → prompt for the code KakaoTalk sends to the user's phone →
+`register_device.json` → retry `login.json`. Endpoints/fields mirror node-kakao's
+`AuthApiClient`. Login itself is a normal auth call (not an unofficial LOCO write), so
+it is not a ban trigger, but repeated logins with a spoofed device should be avoided.
 
 ## TODO
 
@@ -91,7 +94,7 @@ is not a ban trigger, but repeated logins with a spoofed device should be avoide
       `IOPlatformUUID` and calls `login_with_xvc`, saving `credentials.json`. _(v1.3.0)_
 - [x] Document the `auth.password_cmd` / `email_cmd` config path as the unattended
       equivalent. _(troubleshooting + authentication docs)_
-- [ ] Handle KakaoTalk new-device verification (passcode / 2FA) in the `--manual`
-      flow so first-time logins from an unseen device can complete.
+- [x] Handle KakaoTalk new-device verification (passcode / 2FA) in the `--manual`
+      flow so first-time logins from an unseen device can complete. _(v1.3.2, #20)_
 - [ ] (Optional, best-effort) Decrypt the obfuscated plist values per the recipe
       above, behind a version guard.

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -250,6 +250,14 @@ pub fn cmd_login(save: bool) -> Result<()> {
 /// KakaoTalk macOS release.
 const DEFAULT_LOGIN_APP_VERSION: &str = "26.5.0";
 
+/// Device name registered for this client and shown in KakaoTalk's device list.
+const DEVICE_NAME: &str = "openkakao-cli";
+
+/// `login.json` status returned when the device UUID has never been registered on the
+/// account. KakaoTalk requires a passcode-based device registration before it will
+/// hand out a token for an unseen device. See [`register_new_device`].
+const DEVICE_NOT_REGISTERED: i64 = -100;
+
 /// Read the version string the locally installed KakaoTalk app reports
 /// (`CFBundleShortVersionString`). This is exactly what the real app puts in its REST
 /// `A`/`User-Agent` headers, so using it keeps `login --manual` working across
@@ -322,9 +330,17 @@ pub fn cmd_login_manual(
     let client = KakaoRestClient::new(base.clone())?;
 
     eprintln!("Logging in as {} ...", email);
-    let response = client.login_with_xvc(&email, &password, &device_uuid, "openkakao-cli")?;
+    let mut response = client.login_with_xvc(&email, &password, &device_uuid, DEVICE_NAME)?;
+    let mut status = response.get("status").and_then(Value::as_i64).unwrap_or(-1);
 
-    let status = response.get("status").and_then(Value::as_i64).unwrap_or(-1);
+    // -100 = this device_uuid is not registered on the account yet. Run the passcode
+    // verification flow (request_passcode -> register_device), then retry the login.
+    if status == DEVICE_NOT_REGISTERED {
+        register_new_device(&client, &email, &password, &device_uuid)?;
+        response = client.login_with_xvc(&email, &password, &device_uuid, DEVICE_NAME)?;
+        status = response.get("status").and_then(Value::as_i64).unwrap_or(-1);
+    }
+
     if status != 0 {
         let message = response
             .get("message")
@@ -355,6 +371,55 @@ pub fn cmd_login_manual(
     Ok(())
 }
 
+/// Complete KakaoTalk's new-device verification: ask the server to send a passcode,
+/// read it from the user, and register this device's UUID. Called when `login.json`
+/// returns `-100`; on success the caller retries the login and receives a token.
+fn register_new_device(
+    client: &KakaoRestClient,
+    email: &str,
+    password: &str,
+    device_uuid: &str,
+) -> Result<()> {
+    eprintln!();
+    eprintln!("This Mac is not registered on your KakaoTalk account yet.");
+    eprintln!("Requesting a verification passcode from KakaoTalk ...");
+
+    let resp = client.request_passcode(email, password, device_uuid, DEVICE_NAME)?;
+    if let Some((status, message)) = response_error(&resp) {
+        anyhow::bail!("could not request a passcode (status={status}): {message}");
+    }
+
+    eprintln!("KakaoTalk sent a passcode to your phone or another logged-in device.");
+    let passcode = prompt_line("Enter the passcode: ")?;
+    if passcode.is_empty() {
+        anyhow::bail!("passcode is required to register this device");
+    }
+
+    let resp = client.register_device(email, password, device_uuid, DEVICE_NAME, &passcode)?;
+    if let Some((status, message)) = response_error(&resp) {
+        anyhow::bail!("device registration failed (status={status}): {message}");
+    }
+
+    eprintln!("Device registered. Completing login ...");
+    Ok(())
+}
+
+/// Return `(status, message)` when a KakaoTalk JSON reply reports a non-zero status,
+/// or `None` when `status == 0` (success).
+fn response_error(resp: &Value) -> Option<(i64, String)> {
+    let status = resp.get("status").and_then(Value::as_i64).unwrap_or(-1);
+    if status == 0 {
+        return None;
+    }
+    let message = resp
+        .get("message")
+        .or_else(|| resp.get("msg"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    Some((status, message))
+}
+
 fn print_manual_login_failure(status: i64, message: &str) {
     eprintln!("Login failed (status={}).", status);
     if !message.is_empty() {
@@ -371,12 +436,10 @@ fn print_manual_login_failure(status: i64, message: &str) {
         eprintln!("  (find the version in KakaoTalk > About, e.g. 26.5.0)");
         return;
     }
-    // KakaoTalk asks for a second factor / device registration on a new device_uuid.
-    // The exact codes vary by account, so surface a generic hint rather than guess.
-    eprintln!("  If this account requires it, KakaoTalk may be demanding new-device");
-    eprintln!("  verification (a passcode sent to your phone / 2FA). openkakao-cli does");
-    eprintln!("  not yet handle that step. Approve this Mac in the KakaoTalk app first,");
-    eprintln!("  then retry. Double-check the email/phone and password as well.");
+    // Anything else is most likely a wrong email/phone or password. The new-device
+    // passcode flow is handled automatically before we reach this point.
+    eprintln!("  Double-check the email/phone and password and try again.");
+    eprintln!("  If you reached the passcode step, make sure you entered it correctly.");
 }
 
 fn prompt_line(label: &str) -> Result<String> {
@@ -732,5 +795,25 @@ mod tests {
     fn default_is_not_the_rejected_legacy_version() {
         // The old default "3.7.0" is now rejected by KakaoTalk's REST API (#18).
         assert_ne!(DEFAULT_LOGIN_APP_VERSION, "3.7.0");
+    }
+
+    #[test]
+    fn response_error_none_on_success() {
+        assert!(response_error(&serde_json::json!({ "status": 0 })).is_none());
+    }
+
+    #[test]
+    fn response_error_reports_status_and_message() {
+        let (status, message) =
+            response_error(&serde_json::json!({ "status": -100, "message": "x" })).unwrap();
+        assert_eq!(status, DEVICE_NOT_REGISTERED);
+        assert_eq!(message, "x");
+    }
+
+    #[test]
+    fn response_error_missing_status_is_error() {
+        // A reply with no status field is treated as a failure, not a success.
+        let (status, _) = response_error(&serde_json::json!({})).unwrap();
+        assert_eq!(status, -1);
     }
 }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -323,6 +323,19 @@ impl KakaoRestClient {
             "device_name={encoded_name}&device_uuid={encoded_uuid}&email={encoded_email}&os_version=26.1.0&password={encoded_password}&permanent=1"
         );
 
+        self.post_account_form("login.json", &body, x_vc, user_agent)
+    }
+
+    /// POST a urlencoded form to a `/mac/account/<endpoint>` route with the
+    /// unauthenticated header set (A, User-Agent, optional X-VC) and parse the JSON
+    /// reply. Shared by login, request_passcode, and register_device.
+    fn post_account_form(
+        &self,
+        endpoint: &str,
+        body: &str,
+        x_vc: &str,
+        user_agent: &str,
+    ) -> Result<Value> {
         let mut headers = HeaderMap::new();
         headers.insert(
             CONTENT_TYPE,
@@ -355,21 +368,66 @@ impl KakaoRestClient {
 
         let response = self
             .client
-            .post(format!("{BASE_URL}/mac/account/login.json"))
+            .post(format!("{BASE_URL}/mac/account/{endpoint}"))
             .headers(headers)
-            .body(body)
+            .body(body.to_string())
             .send()
-            .context("login.json request failed")?;
+            .with_context(|| format!("{endpoint} request failed"))?;
 
         let text = response.text().context("Failed to read response")?;
-        let parsed: Value = serde_json::from_str(&text).with_context(|| {
+        serde_json::from_str(&text).with_context(|| {
             format!(
-                "Failed to parse login response: {}",
+                "Failed to parse {} response: {}",
+                endpoint,
                 &text[..200.min(text.len())]
             )
-        })?;
+        })
+    }
 
-        Ok(parsed)
+    /// Ask KakaoTalk to send a device-registration passcode (delivered to the user's
+    /// phone or another logged-in device). First step of the new-device verification
+    /// flow that `login.json` triggers with `status=-100`.
+    pub fn request_passcode(
+        &self,
+        email: &str,
+        password: &str,
+        device_uuid: &str,
+        device_name: &str,
+    ) -> Result<Value> {
+        let user_agent = format!("KT/{} Mc/26.1.0 ko", self.creds.app_version);
+        let xvc = Self::generate_xvc(&user_agent, email, device_uuid);
+        let body = format!(
+            "device_name={}&device_uuid={}&email={}&password={}",
+            urlencoding::encode(device_name),
+            urlencoding::encode(device_uuid),
+            urlencoding::encode(email),
+            urlencoding::encode(password),
+        );
+        self.post_account_form("request_passcode.json", &body, &xvc, &user_agent)
+    }
+
+    /// Register this device's UUID against the account using the passcode the user
+    /// received. Second step of the new-device verification flow; once it succeeds the
+    /// next `login.json` for the same `device_uuid` returns a token instead of `-100`.
+    pub fn register_device(
+        &self,
+        email: &str,
+        password: &str,
+        device_uuid: &str,
+        device_name: &str,
+        passcode: &str,
+    ) -> Result<Value> {
+        let user_agent = format!("KT/{} Mc/26.1.0 ko", self.creds.app_version);
+        let xvc = Self::generate_xvc(&user_agent, email, device_uuid);
+        let body = format!(
+            "device_name={}&device_uuid={}&email={}&passcode={}&password={}&permanent=1",
+            urlencoding::encode(device_name),
+            urlencoding::encode(device_uuid),
+            urlencoding::encode(email),
+            urlencoding::encode(passcode),
+            urlencoding::encode(password),
+        );
+        self.post_account_form("register_device.json", &body, &xvc, &user_agent)
     }
 
     pub fn get_settings(&self) -> Result<Value> {


### PR DESCRIPTION
## Summary

On v1.3.1 the version fix (#18) works, but logging in from a Mac the account has never seen now fails with `status=-100` (`DEVICE_NOT_REGISTERED`) — KakaoTalk requires passcode-based device registration before issuing a token (#20). That path was a dead-end.

## Changes

- `login --manual` now completes the new-device verification automatically:
  1. `login.json` → `-100`
  2. `request_passcode.json` — KakaoTalk sends a passcode to the user's phone / another logged-in device
  3. prompt for the passcode
  4. `register_device.json` — registers this device UUID
  5. retry `login.json` → token
- New `KakaoRestClient::request_passcode` / `register_device`; login POST refactored onto a shared `post_account_form` helper. Endpoints/fields mirror node-kakao's `AuthApiClient`.
- Failure hint no longer claims new-device verification is unsupported.
- README + research note updated; 3 new unit tests.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (298 passed).
- ⚠️ The live `-100` → passcode round-trip cannot be exercised from CI (needs a real unregistered-device account state). Endpoints are from authoritative node-kakao source and the change is strictly additive over the current dead-end, so it cannot regress existing behavior. Reporter validation requested in the issue.

Closes #20.

https://claude.ai/code/session_017B3XofKjNWZWvqN9vdmdyq