### PR TITLE
chore: deprecate project; revert broken v1.3.2 passcode flow (#20, #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-06-29
+
+### Deprecated
+- **openkakao-cli is now deprecated and no longer actively maintained.** Recent KakaoTalk macOS builds broke the login paths and they cannot be repaired without ongoing reverse-engineering, which there is no bandwidth for. Every invocation now prints a deprecation notice to stderr (suppress with `OPENKAKAO_CLI_NO_DEPRECATION=1`). The read-only `local-*` commands still work. README marked accordingly.
+
+### Changed
+- **Reverted the v1.3.2 passcode/device-registration flow** (#20, #22): the `request_passcode.json` / `register_device.json` endpoints it relied on do not exist on current KakaoTalk macOS builds (they return 404), so the flow could never complete. `login --manual` now stops on `status=-100` with a clear explanation **and a safety warning not to retry** — repeated logins from an unregistered device have gotten real users' accounts' sub-device login blocked.
+
 ## [1.3.2] - 2026-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"

--- a/README.en.md
+++ b/README.en.md
@@ -16,11 +16,22 @@
   <a href="https://github.com/JungHoonGhae/openkakao-cli/stargazers"><img src="https://img.shields.io/github/stars/JungHoonGhae/openkakao-cli" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust" /></a>
-  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-v1.0.0%20stable-brightgreen" alt="Status Stable" /></a>
+  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-deprecated-red" alt="Status Deprecated" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/docs-fumadocs-black" alt="Docs" /></a>
 </p>
 
 [한국어](README.md) | **English**
+
+> [!CAUTION]
+> **Deprecated / maintenance paused (2026-06)** — Due to personal work commitments, this project is not being actively maintained right now. The login issues below may remain unresolved.
+>
+> Recent KakaoTalk macOS builds broke **most login paths:**
+> - `login --save` — newer builds no longer cache the auth token, so it cannot be extracted. ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15))
+> - `login --manual` — an unseen device gets `status=-100` (device not registered), but the current macOS app has no automated device-registration (passcode) endpoint (it 404s), so login cannot complete. ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22))
+>
+> **🚨 Do NOT repeatedly retry login from an unregistered device.** Kakao may block your account's "sub-device login" or restrict the account (this has actually been reported).
+>
+> For relatively safe, server-free use, stick to the `local-*` commands (local DB, read-only).
 
 > [!WARNING]
 > This project is an unofficial CLI and is not affiliated with or endorsed by Kakao Corp. It is built for research, automation, and local workflows around the macOS KakaoTalk app.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@
   <a href="https://github.com/JungHoonGhae/openkakao-cli/stargazers"><img src="https://img.shields.io/github/stars/JungHoonGhae/openkakao-cli" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust" /></a>
-  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-v1.0.0%20stable-brightgreen" alt="Status Stable" /></a>
+  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-deprecated-red" alt="Status Deprecated" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/docs-fumadocs-black" alt="Docs" /></a>
 </p>
 
 **한국어** | [English](README.en.md)
+
+> [!CAUTION]
+> **유지보수 중단 / Deprecated (2026-06)** — 개인 업무 사정 등으로 현재 이 프로젝트를 지속적으로 유지보수하기 어렵습니다. 아래 로그인 이슈가 해결되지 않은 채 남아 있을 수 있습니다.
+>
+> 최근 KakaoTalk macOS 빌드 변경으로 **로그인 경로가 대부분 동작하지 않습니다:**
+> - `login --save` — 최신 빌드는 인증 토큰을 캐시에 남기지 않아 추출이 불가능합니다. ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15))
+> - `login --manual` — 처음 보는 기기는 `status=-100`(기기 미등록)을 받는데, 현재 macOS 앱에는 자동 기기 등록(passcode) 엔드포인트가 없어(404) 로그인을 완료할 수 없습니다. ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22))
+>
+> **🚨 미등록 기기로 로그인을 반복 시도하지 마세요.** 카카오가 계정의 "서브 디바이스 로그인"을 차단하거나 계정을 제재할 수 있습니다(실제 피해 사례가 보고되었습니다).
+>
+> 서버 통신 없이 비교적 안전하게 쓰려면 `local-*` 명령(로컬 DB 읽기 전용)만 사용하세요.
 
 > [!WARNING]
 > 이 프로젝트는 카카오(Kakao Corp.)와 무관한 비공식 CLI입니다. 연구, 자동화, 로컬 워크플로 용도로 만들었고, 카카오의 승인이나 보증을 받지 않았습니다.

--- a/docs/research/credential-storage.md
+++ b/docs/research/credential-storage.md
@@ -80,13 +80,16 @@ depend on `Cache.db`:
 working `login --save`) has no UUID and is blocked. Generating it from
 `IOPlatformUUID` closes the gap and makes email+password login fully self-sufficient.
 
-**New-device verification (handled since v1.3.2, #20):** logging in with a fresh
-`device_uuid` makes `login.json` return `status=-100` (DEVICE_NOT_REGISTERED). The
-`--manual` flow now completes the passcode handshake automatically:
-`request_passcode.json` → prompt for the code KakaoTalk sends to the user's phone →
-`register_device.json` → retry `login.json`. Endpoints/fields mirror node-kakao's
-`AuthApiClient`. Login itself is a normal auth call (not an unofficial LOCO write), so
-it is not a ban trigger, but repeated logins with a spoofed device should be avoided.
+**New-device verification (UNRESOLVED — attempted then reverted):** logging in with a
+fresh `device_uuid` makes `login.json` return `status=-100` (DEVICE_NOT_REGISTERED).
+v1.3.2 tried to complete a passcode handshake (`request_passcode.json` →
+`register_device.json`, mirroring node-kakao's `AuthApiClient`), but those routes
+**do not exist on current KakaoTalk macOS builds — they return HTTP 404** (confirmed by
+two users, one via binary analysis: #20, #22). The flow was reverted in v1.3.3.
+**Critically, repeated `login.json` attempts from an unregistered device have gotten
+real users' accounts' "sub-device login" blocked** — so this must not be brute-forced.
+There is currently no known macOS REST path to register a new device from a
+third-party client; the project is deprecated as of v1.3.3.
 
 ## TODO
 
@@ -94,7 +97,9 @@ it is not a ban trigger, but repeated logins with a spoofed device should be avo
       `IOPlatformUUID` and calls `login_with_xvc`, saving `credentials.json`. _(v1.3.0)_
 - [x] Document the `auth.password_cmd` / `email_cmd` config path as the unattended
       equivalent. _(troubleshooting + authentication docs)_
-- [x] Handle KakaoTalk new-device verification (passcode / 2FA) in the `--manual`
-      flow so first-time logins from an unseen device can complete. _(v1.3.2, #20)_
+- [ ] ~~Handle KakaoTalk new-device verification (passcode / 2FA) in the `--manual`
+      flow~~ — attempted in v1.3.2, reverted in v1.3.3: the macOS app no longer exposes
+      the passcode/register_device endpoints (404), and retrying risks an account block
+      (#20, #22). No known path; project deprecated.
 - [ ] (Optional, best-effort) Decrypt the obfuscated plist values per the recipe
       above, behind a version guard.

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -330,15 +330,17 @@ pub fn cmd_login_manual(
     let client = KakaoRestClient::new(base.clone())?;
 
     eprintln!("Logging in as {} ...", email);
-    let mut response = client.login_with_xvc(&email, &password, &device_uuid, DEVICE_NAME)?;
-    let mut status = response.get("status").and_then(Value::as_i64).unwrap_or(-1);
+    let response = client.login_with_xvc(&email, &password, &device_uuid, DEVICE_NAME)?;
+    let status = response.get("status").and_then(Value::as_i64).unwrap_or(-1);
 
-    // -100 = this device_uuid is not registered on the account yet. Run the passcode
-    // verification flow (request_passcode -> register_device), then retry the login.
+    // -100 = this device_uuid is not registered on the account yet. Recent KakaoTalk
+    // macOS builds removed the passcode/register_device REST endpoints (they 404), so
+    // there is no automated way to register the device from the CLI. Stop here with a
+    // clear warning instead of retrying — repeated logins from an unregistered device
+    // can get the account's sub-device login blocked (#20, #22). DEPRECATED.
     if status == DEVICE_NOT_REGISTERED {
-        register_new_device(&client, &email, &password, &device_uuid)?;
-        response = client.login_with_xvc(&email, &password, &device_uuid, DEVICE_NAME)?;
-        status = response.get("status").and_then(Value::as_i64).unwrap_or(-1);
+        print_device_not_registered_warning();
+        anyhow::bail!("login failed (status=-100, device not registered)");
     }
 
     if status != 0 {
@@ -371,53 +373,23 @@ pub fn cmd_login_manual(
     Ok(())
 }
 
-/// Complete KakaoTalk's new-device verification: ask the server to send a passcode,
-/// read it from the user, and register this device's UUID. Called when `login.json`
-/// returns `-100`; on success the caller retries the login and receives a token.
-fn register_new_device(
-    client: &KakaoRestClient,
-    email: &str,
-    password: &str,
-    device_uuid: &str,
-) -> Result<()> {
+/// Explain `status=-100` (device not registered) and, critically, warn the user not to
+/// keep retrying. A passcode/device-registration REST flow once existed in other Kakao
+/// clients, but recent KakaoTalk macOS builds no longer expose it (the endpoints 404),
+/// so the CLI cannot register a new device. Repeated attempts risk an account block.
+fn print_device_not_registered_warning() {
     eprintln!();
-    eprintln!("This Mac is not registered on your KakaoTalk account yet.");
-    eprintln!("Requesting a verification passcode from KakaoTalk ...");
-
-    let resp = client.request_passcode(email, password, device_uuid, DEVICE_NAME)?;
-    if let Some((status, message)) = response_error(&resp) {
-        anyhow::bail!("could not request a passcode (status={status}): {message}");
-    }
-
-    eprintln!("KakaoTalk sent a passcode to your phone or another logged-in device.");
-    let passcode = prompt_line("Enter the passcode: ")?;
-    if passcode.is_empty() {
-        anyhow::bail!("passcode is required to register this device");
-    }
-
-    let resp = client.register_device(email, password, device_uuid, DEVICE_NAME, &passcode)?;
-    if let Some((status, message)) = response_error(&resp) {
-        anyhow::bail!("device registration failed (status={status}): {message}");
-    }
-
-    eprintln!("Device registered. Completing login ...");
-    Ok(())
-}
-
-/// Return `(status, message)` when a KakaoTalk JSON reply reports a non-zero status,
-/// or `None` when `status == 0` (success).
-fn response_error(resp: &Value) -> Option<(i64, String)> {
-    let status = resp.get("status").and_then(Value::as_i64).unwrap_or(-1);
-    if status == 0 {
-        return None;
-    }
-    let message = resp
-        .get("message")
-        .or_else(|| resp.get("msg"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-    Some((status, message))
+    eprintln!("This Mac is not registered on your KakaoTalk account, and KakaoTalk's");
+    eprintln!("current macOS builds no longer expose an endpoint to register it from a");
+    eprintln!("third-party client (the passcode/register_device routes return 404).");
+    eprintln!("openkakao-cli cannot complete this login. (#20, #22)");
+    eprintln!();
+    eprintln!("  🚨 Do NOT keep retrying. Repeated logins from an unregistered device");
+    eprintln!("     can get your account's sub-device login blocked or the account");
+    eprintln!("     restricted. This has actually happened to other users.");
+    eprintln!();
+    eprintln!("  This project is deprecated and no longer actively maintained.");
+    eprintln!("  For server-free use, the read-only 'local-*' commands still work.");
 }
 
 fn print_manual_login_failure(status: i64, message: &str) {
@@ -436,10 +408,9 @@ fn print_manual_login_failure(status: i64, message: &str) {
         eprintln!("  (find the version in KakaoTalk > About, e.g. 26.5.0)");
         return;
     }
-    // Anything else is most likely a wrong email/phone or password. The new-device
-    // passcode flow is handled automatically before we reach this point.
+    // -100 is handled separately; anything else here is most likely a wrong
+    // email/phone or password.
     eprintln!("  Double-check the email/phone and password and try again.");
-    eprintln!("  If you reached the passcode step, make sure you entered it correctly.");
 }
 
 fn prompt_line(label: &str) -> Result<String> {
@@ -798,22 +769,8 @@ mod tests {
     }
 
     #[test]
-    fn response_error_none_on_success() {
-        assert!(response_error(&serde_json::json!({ "status": 0 })).is_none());
-    }
-
-    #[test]
-    fn response_error_reports_status_and_message() {
-        let (status, message) =
-            response_error(&serde_json::json!({ "status": -100, "message": "x" })).unwrap();
-        assert_eq!(status, DEVICE_NOT_REGISTERED);
-        assert_eq!(message, "x");
-    }
-
-    #[test]
-    fn response_error_missing_status_is_error() {
-        // A reply with no status field is treated as a failure, not a success.
-        let (status, _) = response_error(&serde_json::json!({})).unwrap();
-        assert_eq!(status, -1);
+    fn device_not_registered_code_is_stable() {
+        // -100 drives the deprecation warning path in cmd_login_manual (#20, #22).
+        assert_eq!(DEVICE_NOT_REGISTERED, -100);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -576,6 +576,17 @@ fn main() -> Result<()> {
         NO_COLOR.store(true, Ordering::Relaxed);
     }
 
+    // Deprecation notice — printed to stderr so it never corrupts JSON on stdout.
+    // Silenced with OPENKAKAO_CLI_NO_DEPRECATION=1 for scripted local-only use.
+    if std::env::var_os("OPENKAKAO_CLI_NO_DEPRECATION").is_none() {
+        eprintln!("⚠️  openkakao-cli is DEPRECATED and no longer actively maintained.");
+        eprintln!("   Login is broken on recent KakaoTalk macOS builds. Do NOT repeatedly retry");
+        eprintln!("   login on an unregistered device — it can get your account's sub-device");
+        eprintln!(
+            "   login blocked. Read-only 'local-*' commands are the safest path. See README."
+        );
+    }
+
     match cli.command {
         Commands::Auth => commands::auth::cmd_auth(json)?,
         Commands::AuthStatus => commands::auth::cmd_auth_status(json)?,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -384,51 +384,10 @@ impl KakaoRestClient {
         })
     }
 
-    /// Ask KakaoTalk to send a device-registration passcode (delivered to the user's
-    /// phone or another logged-in device). First step of the new-device verification
-    /// flow that `login.json` triggers with `status=-100`.
-    pub fn request_passcode(
-        &self,
-        email: &str,
-        password: &str,
-        device_uuid: &str,
-        device_name: &str,
-    ) -> Result<Value> {
-        let user_agent = format!("KT/{} Mc/26.1.0 ko", self.creds.app_version);
-        let xvc = Self::generate_xvc(&user_agent, email, device_uuid);
-        let body = format!(
-            "device_name={}&device_uuid={}&email={}&password={}",
-            urlencoding::encode(device_name),
-            urlencoding::encode(device_uuid),
-            urlencoding::encode(email),
-            urlencoding::encode(password),
-        );
-        self.post_account_form("request_passcode.json", &body, &xvc, &user_agent)
-    }
-
-    /// Register this device's UUID against the account using the passcode the user
-    /// received. Second step of the new-device verification flow; once it succeeds the
-    /// next `login.json` for the same `device_uuid` returns a token instead of `-100`.
-    pub fn register_device(
-        &self,
-        email: &str,
-        password: &str,
-        device_uuid: &str,
-        device_name: &str,
-        passcode: &str,
-    ) -> Result<Value> {
-        let user_agent = format!("KT/{} Mc/26.1.0 ko", self.creds.app_version);
-        let xvc = Self::generate_xvc(&user_agent, email, device_uuid);
-        let body = format!(
-            "device_name={}&device_uuid={}&email={}&passcode={}&password={}&permanent=1",
-            urlencoding::encode(device_name),
-            urlencoding::encode(device_uuid),
-            urlencoding::encode(email),
-            urlencoding::encode(passcode),
-            urlencoding::encode(password),
-        );
-        self.post_account_form("register_device.json", &body, &xvc, &user_agent)
-    }
+    // NOTE: a passcode/register_device flow (request_passcode.json,
+    // register_device.json) was attempted in v1.3.2 to handle status=-100, but recent
+    // KakaoTalk macOS builds do not expose those routes (they 404). It was removed in
+    // v1.3.3 to avoid encouraging retries that can get an account blocked. See #20/#22.
 
     pub fn get_settings(&self) -> Result<Value> {
         self.request(


### PR DESCRIPTION
## Why

v1.3.2 added a passcode/device-registration flow for `status=-100`, based on node-kakao's endpoints. Two users confirmed those routes **do not exist on current KakaoTalk macOS builds** — `request_passcode.json` returns **HTTP 404** (one user verified via binary analysis that the URL isn't in the app). The flow can never complete, and repeated `-100` login attempts have gotten real users' accounts' **sub-device login blocked**.

## Changes

- **Revert the passcode flow.** On `-100`, `login --manual` now stops with a clear explanation **and a warning not to retry** (account-block risk). Removed `request_passcode` / `register_device`.
- **Deprecation notice** printed on every run (stderr, so JSON on stdout is unaffected; suppress with `OPENKAKAO_CLI_NO_DEPRECATION=1`).
- README (ko/en) marked **deprecated** with the login-broken + account-block warning; status badge → deprecated. Research note + CHANGELOG updated. Bumps to 1.3.3.
- The read-only `local-*` commands are unaffected.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (all pass).
- Manually verified the banner prints to stderr and `OPENKAKAO_CLI_NO_DEPRECATION=1` suppresses it.

Refs #20, #22.

https://claude.ai/code/session_017B3XofKjNWZWvqN9vdmdyq