### PR TITLE
docs(website): mark project deprecated; login broken on recent KakaoTalk builds

### DIFF
--- a/website/content/docs/getting-started/authentication.mdx
+++ b/website/content/docs/getting-started/authentication.mdx
@@ -5,6 +5,12 @@ description: How OpenKakao authenticates, how recovery policy works, and where u
 
 # Authentication
 
+<Callout type="warn" title="Deprecated — login does not work on recent KakaoTalk builds">
+As of 2026-06 this project is no longer actively maintained, and the login flows below are broken on current KakaoTalk macOS builds. `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)); `login --manual` returns `status=-100` (device not registered) and there is no working device-registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
+
+**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** The read-only `local-*` commands still work without authenticating to Kakao's servers.
+</Callout>
+
 OpenKakao derives authentication material from the running KakaoTalk macOS app and stores reusable credentials locally only when you ask it to.
 
 ## Token classes
@@ -18,7 +24,7 @@ OpenKakao derives authentication material from the running KakaoTalk macOS app a
 | `refresh_token` renewal | renewal endpoints + cached refresh token | supervised token refresh attempts |
 | `auth.password_cmd` | external secret command such as Doppler | unattended relogin without storing a plaintext password locally |
 
-`login --manual` is the recommended starting point on current KakaoTalk macOS builds: it does not read `Cache.db`, deriving the device UUID from `IOPlatformUUID` and computing the X-VC header locally. See [Troubleshooting → Manual login](/docs/getting-started/troubleshooting) for the new-device verification caveat.
+`login --manual` was the recommended starting point, but on current KakaoTalk macOS builds it fails for any device the account has not seen before: `login.json` returns `status=-100` (device not registered) and KakaoTalk no longer exposes a passcode/registration endpoint the CLI can call (it 404s). There is no known workaround — see [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20) and [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22). Use the read-only `local-*` commands instead.
 
 ## Transport boundary
 

--- a/website/content/docs/getting-started/quickstart.mdx
+++ b/website/content/docs/getting-started/quickstart.mdx
@@ -6,6 +6,10 @@ icon: Rocket
 
 import { KeyRound, ListTree, MessageSquareText, Terminal } from 'lucide-react';
 
+<Callout type="warn" title="Deprecated — authentication is broken (2026-06)">
+This project is no longer actively maintained, and login no longer works on recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The "Authenticate once" step below will fail. **Do not repeatedly retry login — it can get your account's sub-device login blocked.** Only the read-only `local-*` commands still work.
+</Callout>
+
 ## Introduction
 
 This path is intentionally narrow: install, authenticate, inspect a chat, then stop and evaluate whether the trust model fits your use case.

--- a/website/content/docs/getting-started/troubleshooting.mdx
+++ b/website/content/docs/getting-started/troubleshooting.mdx
@@ -5,6 +5,10 @@ description: Common failure modes when login, LOCO, or watch mode do not behave 
 
 # Troubleshooting
 
+<Callout type="warn" title="Deprecated — login is broken on recent KakaoTalk builds (2026-06)">
+This project is no longer actively maintained, and **both login paths below fail on current KakaoTalk macOS builds.** `login --save` can't find a token in the cache, and `login --manual` hits `status=-100` with no working device-registration endpoint. **Do not repeatedly retry `--manual` — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The read-only `local-*` commands still work.
+</Callout>
+
 ## KakaoTalk macOS compatibility for `login --save`
 
 `login --save` works by reading the KakaoTalk macOS app's HTTP cache (`Cache.db`) and pulling the `Authorization` header out of cached REST responses. Recent KakaoTalk macOS builds have changed how they cache responses — authenticated REST calls are no longer written to `NSURLCache`. On those builds:
@@ -13,13 +17,7 @@ description: Common failure modes when login, LOCO, or watch mode do not behave 
 - v1.2.2+ detects this and prints a dedicated message pointing at issue [#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15).
 - "Open the app and click a chat" does **not** help on these builds — the request never reaches `Cache.db` regardless of activity.
 
-If you see the "contains zero entries with an Authorization header" message, use **email + password login** instead — it does not touch the cache:
-
-```bash
-openkakao-cli login --manual --save
-```
-
-See "Manual login (`--manual`)" below. A cache-free auto-extraction path is still tracked in #15.
+If you see the "contains zero entries with an Authorization header" message, there is currently no working recovery: `login --manual` (the former fallback) is also broken on these builds — see the **Manual login** section below. This is tracked in [#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15).
 
 ## `login --save` says "Could not extract credentials"
 
@@ -60,22 +58,18 @@ For verbose output during the scan:
 OPENKAKAO_CLI_DEBUG=1 openkakao-cli login --save
 ```
 
-## Manual login (`--manual`)
+## Manual login (`--manual`) — broken on recent builds
 
-When the cache cannot provide a token (the compatibility case above), log in directly with your KakaoTalk email/phone and password. This path does not read `Cache.db` at all — it derives the device UUID from the Mac's `IOPlatformUUID`, computes the X-VC header locally, and gets a fresh token from `login.json`:
+`login --manual` logs in directly with your KakaoTalk email/phone and password, deriving the device UUID from the Mac's `IOPlatformUUID` and computing the X-VC header locally:
 
 ```bash
 openkakao-cli login --manual --save
 ```
 
-You will be prompted for your email/phone and password (the password input is hidden). Non-interactive use:
+<Callout type="warn" title="This no longer completes on current KakaoTalk builds">
+On recent KakaoTalk macOS builds, logging in from a device the account has not seen before makes `login.json` return `status=-100` (device not registered). The official app once exposed a passcode/`register_device` step to clear this, but those REST endpoints no longer exist on macOS (they return **HTTP 404**, confirmed via binary analysis in [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). v1.3.2 tried to automate the passcode flow; it could not work and was reverted in v1.3.3.
 
-```bash
-openkakao-cli login --manual --save --email you@example.com --password "$KAKAO_PW"
-```
-
-<Callout type="warn" title="New-device verification">
-  Logging in from a device KakaoTalk has not seen before can trigger a passcode / 2FA challenge. openkakao-cli does not yet complete that step — approve this Mac in the KakaoTalk app first, then retry. Login is a normal auth call, not an unofficial protocol write, so it does not by itself risk your account; avoid repeated logins with a spoofed device.
+**🚨 Do not keep retrying.** Repeated logins from an unregistered device have gotten real users' accounts' **sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20)). There is no known workaround, and the project is now deprecated. Use the read-only `local-*` commands, which never authenticate to Kakao's servers.
 </Callout>
 
 ### Writing `credentials.json` by hand

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -5,6 +5,12 @@ description: Developer docs for bringing KakaoTalk into local workflows on macOS
 
 import { Bot, History, Send, ShieldCheck } from 'lucide-react';
 
+<Callout type="warn" title="Deprecated — login is broken on recent KakaoTalk builds (2026-06)">
+This project is no longer actively maintained. Recent KakaoTalk macOS builds broke the login paths: `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)), and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
+
+**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** The read-only `local-*` commands still work.
+</Callout>
+
 ## Introduction
 
 OpenKakao is a beta-stage unofficial KakaoTalk CLI for macOS for developers, terminal-native users, and automation-heavy workflows. It opens a usable local surface around chats, history, watch events, and controlled outbound actions.

--- a/website/content/docs/overview/changelog.mdx
+++ b/website/content/docs/overview/changelog.mdx
@@ -5,6 +5,10 @@ description: Release notes for OpenKakao.
 
 # Changelog
 
+<Callout type="warn" title="Deprecated as of v1.3.3 (2026-06)">
+This project is no longer actively maintained. Recent KakaoTalk macOS builds broke login: `login --save` can't extract a token, and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS. **Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The read-only `local-*` commands still work. v1.3.2's automated passcode flow relied on endpoints that do not exist on macOS and was reverted in v1.3.3.
+</Callout>
+
 ## v1.1.0
 
 **Safety-first defaults, local DB reading, dry-run, memo chat shortcut.**


### PR DESCRIPTION
Adds deprecation callouts to the docs site so visitors see the same notice as the README:

- **Intro, Getting Started, Authentication, Troubleshooting, Changelog** — `<Callout type="warn">` explaining login is broken on recent KakaoTalk macOS builds and **not to retry `--manual` on an unregistered device** (account-block risk).
- Rewrites the Authentication + Troubleshooting "Manual login" sections, which previously presented `--manual` as the working fix. Now they explain `status=-100` / the 404 registration endpoint and point to the read-only `local-*` commands.

Refs #20, #22. Pairs with the v1.3.3 CLI deprecation (#23).

https://claude.ai/code/session_017B3XofKjNWZWvqN9vdmdyq