### PR TITLE
feat(local-send): AX-only rewrite, add ax-read, un-deprecate (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-02
+
+### Un-deprecated
+- **Project maintenance resumes.** LOCO/REST server login (`login --save`, `login --manual`) is still broken on recent KakaoTalk macOS builds and remains unfixed (#15, #20, #22) — but `local-send` and the new `ax-read` now give a fully login-free path for both sending and reading, so the CLI is useful again without a working server session. README/website deprecation notices updated accordingly.
+
+### Changed
+- **`local-send` rewritten to be entirely AX-based, dropping its local-DB dependency.** The command signature changed from `local-send <chat_id> <message>` to `local-send <chat_name> <message>` — `chat_id` was a local-SQLCipher-DB concept, and that DB's key-derivation formula no longer matches current KakaoTalk builds (confirmed independently; not a porting bug, Kakao's client-side crypto has drifted). `local-send` now looks up the chat by display name directly in KakaoTalk's Accessibility (AX) tree and verifies delivery by scraping the opened chat window's own message list — no server contact and no local database read anywhere in the path.
+- Chat-name matching in `local-send`/`ax-read` is now **exact-match only** (previously substring), and refuses to guess when more than one visible chat shares the same display name — there is no chat-id to disambiguate with anymore.
+
+### Added
+- **`ax-read <chat_name>`**: read the most recently visible messages in a chat via the same AX scraping used by `local-send`'s delivery verification — no server contact, no local DB access. Only messages already rendered in the open chat window are returned; scroll up in KakaoTalk first for older history.
+- **`safety.allowed_send_chats`**: an exact-match allowlist in `config.toml` that `local-send` now requires for real (non-dry-run) sends. AX-send has no chat-id-based cross-check, so this is the only guard against a typo or name collision sending to the wrong chat.
+
+### Fixed
+- `local-send`/`ax-read` no longer pick up the wrong `AXTable` when a chat window is already open alongside the main chat list — row/table lookups are now scoped to KakaoTalk's main window (`AXIdentifier == "Main Window"`) specifically.
+- `local-send`/`ax-read` now switch the main window to the chat-list ("chatrooms") tab before searching it, so a chat list search issued while the Friends tab happens to be active no longer fails to find the target row.
+- Fixed `AXSelectedRows` being set on the row element instead of the table element (`kAXErrorAttributeUnsupported`) when selecting a chat row.
+
 ## [1.3.3] - 2026-06-29
 
 ### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,28 @@
 version = 4
 
 [[package]]
+name = "accessibility"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9f33ffc1ef16eddb2451c03c983e56a5182ac760c3f2733da55ba8f48eac4"
+dependencies = [
+ "accessibility-sys",
+ "cocoa",
+ "core-foundation",
+ "objc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "accessibility-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a6a8e90a1d8b96a48249e7c8f5b4058447bea8847280db7bfccb6dcab6b8e1"
+dependencies = [
+ "core-foundation-sys",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +450,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics 0.24.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "objc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,10 +509,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -656,6 +760,33 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1216,6 +1347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,8 +1469,10 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
+ "accessibility",
+ "accessibility-sys",
  "aes-gcm",
  "anyhow",
  "assert_cmd",
@@ -1331,10 +1482,13 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "core-foundation",
+ "core-graphics 0.25.0",
  "csv",
  "dirs",
  "hex",
  "hmac",
+ "libc",
  "owo-colors",
  "plist",
  "predicates",
@@ -1348,7 +1502,7 @@ dependencies = [
  "sha1",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls",
@@ -1568,7 +1722,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1589,7 +1743,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1712,7 +1866,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2030,6 +2184,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2178,11 +2342,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"
@@ -14,6 +14,8 @@ name = "openkakao_cli"
 path = "src/lib.rs"
 
 [dependencies]
+accessibility = "0.2"
+accessibility-sys = "0.2"
 aes-gcm = "0.10"
 anyhow = "1.0"
 base64 = "0.22"
@@ -22,10 +24,13 @@ byteorder = "1.5"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
+core-foundation = "0.10"
+core-graphics = { version = "0.25", features = ["elcapitan"] }
 csv = "1.3"
 dirs = "6.0"
 hex = "0.4"
 hmac = "0.12"
+libc = "0.2"
 plist = "1.7"
 rand = "0.8"
 rpassword = "7"
@@ -46,6 +51,9 @@ owo-colors = "4"
 urlencoding = "2.1"
 webpki-roots = "0.26"
 zeroize = { version = "1", features = ["derive"] }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+sha2 = { version = "0.10", features = ["asm-aarch64"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.en.md
+++ b/README.en.md
@@ -16,22 +16,20 @@
   <a href="https://github.com/JungHoonGhae/openkakao-cli/stargazers"><img src="https://img.shields.io/github/stars/JungHoonGhae/openkakao-cli" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust" /></a>
-  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-deprecated-red" alt="Status Deprecated" /></a>
+  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-active-brightgreen" alt="Status Active" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/docs-fumadocs-black" alt="Docs" /></a>
 </p>
 
 [한국어](README.md) | **English**
 
-> [!CAUTION]
-> **Deprecated / maintenance paused (2026-06)** — Due to personal work commitments, this project is not being actively maintained right now. The login issues below may remain unresolved.
->
-> Recent KakaoTalk macOS builds broke **most login paths:**
+> [!IMPORTANT]
+> **Server login is broken (2026-06~)** — Recent KakaoTalk macOS builds broke **most login paths:**
 > - `login --save` — newer builds no longer cache the auth token, so it cannot be extracted. ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15))
 > - `login --manual` — an unseen device gets `status=-100` (device not registered), but the current macOS app has no automated device-registration (passcode) endpoint (it 404s), so login cannot complete. ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22))
 >
 > **🚨 Do NOT repeatedly retry login from an unregistered device.** Kakao may block your account's "sub-device login" or restrict the account (this has actually been reported).
 >
-> For relatively safe, server-free use, stick to the `local-*` commands (local DB, read-only).
+> **But the CLI works fully without logging in.** `local-send`/`ax-read` drive the real KakaoTalk UI directly via the macOS Accessibility API — no server session needed for either sending real messages or reading recent chat history (see [Quick Start](#quick-start) below). The local SQLCipher DB path (`local-chats`/`local-read`/`local-search`) is currently unreliable on recent builds — its key-derivation formula has drifted from what current KakaoTalk uses.
 
 > [!WARNING]
 > This project is an unofficial CLI and is not affiliated with or endorsed by Kakao Corp. It is built for research, automation, and local workflows around the macOS KakaoTalk app.
@@ -68,15 +66,33 @@
 
 ## Quick Start
 
-### For Human
+### Login-free path (recommended)
+
+No server login needed — just KakaoTalk running and already logged in.
 
 ```bash
 # Homebrew
 brew tap JungHoonGhae/openkakao
 brew install openkakao-cli
 
-# 1. Save auth data
-#    Recent KakaoTalk no longer caches the token, so email+password login is recommended (#15)
+# 1. Allowlist the chat before any real send (required — guards against sending to the wrong chat)
+#    ~/.config/openkakao/config.toml
+#    [safety]
+#    allow_ax_send = true
+#    allowed_send_chats = ["the exact display name shown in your chat list"]
+
+# 2. Send a message — no server contact, drives the real KakaoTalk UI directly
+openkakao-cli local-send "chat display name" "Hello from CLI!" --dry-run   # preview
+openkakao-cli local-send "chat display name" "Hello from CLI!" -y         # actually send
+
+# 3. Read recent messages — same AX approach, scrapes what's rendered on screen
+openkakao-cli ax-read "chat display name" -n 20
+```
+
+### Server-login path (mostly broken right now)
+
+```bash
+# 1. Save auth data — fails on most recent builds (#15, #20, #22)
 openkakao-cli login --manual --save
 #    (older builds where cache extraction still works: openkakao-cli login --save)
 
@@ -86,7 +102,7 @@ openkakao-cli chats
 # 3. Read messages
 openkakao-cli read <chat_id> -n 20
 
-# 4. Read from local DB (no server contact)
+# 4. Read from local DB (unreliable on current builds — see ax-read above)
 openkakao-cli local-chats
 openkakao-cli local-read <chat_id>
 
@@ -105,13 +121,13 @@ openkakao-cli members <chat_id> --rest
 ### For Agent
 
 ```bash
+# Login-free read + write (no server contact, AX-based)
+openkakao-cli ax-read "chat display name" -n 20 --json
+openkakao-cli local-send "chat display name" "message" -y --json
+
 # Structured output
 openkakao-cli --json chats
 openkakao-cli --json read <chat_id> -n 20
-
-# Safe local DB reads (no server contact)
-openkakao-cli local-chats --json
-openkakao-cli local-read <chat_id> --json
 
 # Preview before executing
 openkakao-cli send <chat_id> "message" --dry-run --json
@@ -132,16 +148,18 @@ npx skills add JungHoonGhae/skills@openkakao-cli
 
 ## Highlights
 
+- Send and read real messages **without logging in**, via `local-send`/`ax-read` (drives the KakaoTalk UI directly through the macOS Accessibility API, no server contact)
 - Extracts auth data from the macOS KakaoTalk app
 - Reads chats, messages, members, friends, and profiles
 - Sends messages, watches real-time events, and handles media over LOCO
 - Fits well into `jq`, `cron`, SQLite, and LLM workflows through `--json`
 - Connects to local automation and agent flows through `watch`, hooks, and webhooks
 - Can recover some reads with `friends --local`, `profile --local`, and `profile --chat-id`
-- Read safely from local DB with `local-chats`, `local-read`, `local-search` (no server contact)
+- Local DB reads via `local-chats`, `local-read`, `local-search` (unreliable on current builds — prefer `ax-read`)
 - Preview any write with `--dry-run` before executing
 - Send to memo chat with `send --me` for quick testing
 - LOCO write ops disabled by default — opt in with `safety.allow_loco_write = true`
+- `local-send` also disabled by default — opt in with `safety.allow_ax_send = true` plus a `safety.allowed_send_chats` allowlist
 
 ## Where It Fits
 
@@ -161,16 +179,27 @@ To protect your account, commands that write to the server require explicit opt-
 allow_loco_write = true
 ```
 
+`local-send` (AX-based real sending) is also disabled by default as of v1.4.0, and needs its own opt-in plus a **chat allowlist**. `local-send` matches chats by exact display-name text in the chat list, and there is no chat-id left to cross-check the target against, so the allowlist is the only guard against sending to the wrong chat:
+
+```toml
+# ~/.config/openkakao/config.toml
+[safety]
+allow_ax_send = true
+allowed_send_chats = ["your memo chat's display name", "another allowed chat"]
+```
+
 Read-only operations are always available:
 
 | Command | Description | Server Contact |
 |---------|-------------|----------------|
-| `local-chats` | List chats from local DB | None |
-| `local-read <id>` | Read messages from local DB | None |
-| `local-search "keyword"` | Search local DB | None |
+| `ax-read <chat_name>` | Scrape recent messages from an open chat window (AX) | None |
+| `local-chats` | List chats from local DB (unreliable on current builds) | None |
+| `local-read <id>` | Read messages from local DB (unreliable on current builds) | None |
+| `local-search "keyword"` | Search local DB (unreliable on current builds) | None |
 | `chats --rest` | List chats via REST | REST |
 | `read <id> --rest` | Read messages via REST | REST |
 | `send ... --dry-run` | Preview send without executing | None |
+| `local-send ... --dry-run` | Preview an AX send without executing | None |
 
 ## Requirements
 
@@ -240,6 +269,11 @@ If this tool helps you, consider supporting its maintenance:
 ## Contributing
 
 Bug reports and PRs are welcome.
+
+## Acknowledgments
+
+- [kakaocli](https://github.com/silver-flight-group/kakaocli) (MIT) — `local-send`'s macOS Accessibility API automation (selecting chat rows, locating/driving the message input field) was ported to Rust from this project (`src/ax_send.rs`).
+- [Peekaboo](https://github.com/steipete/Peekaboo) (MIT) — `local-send` posts events directly to the target process via `CGEventPostToPid`, an approach borrowed from Peekaboo, to avoid the foreground-activation timing race that kakaocli's `send` hits ([silver-flight-group/kakaocli#9](https://github.com/silver-flight-group/kakaocli/issues/9)).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,22 +16,20 @@
   <a href="https://github.com/JungHoonGhae/openkakao-cli/stargazers"><img src="https://img.shields.io/github/stars/JungHoonGhae/openkakao-cli" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust" /></a>
-  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-deprecated-red" alt="Status Deprecated" /></a>
+  <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-active-brightgreen" alt="Status Active" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/docs-fumadocs-black" alt="Docs" /></a>
 </p>
 
 **한국어** | [English](README.en.md)
 
-> [!CAUTION]
-> **유지보수 중단 / Deprecated (2026-06)** — 개인 업무 사정 등으로 현재 이 프로젝트를 지속적으로 유지보수하기 어렵습니다. 아래 로그인 이슈가 해결되지 않은 채 남아 있을 수 있습니다.
->
-> 최근 KakaoTalk macOS 빌드 변경으로 **로그인 경로가 대부분 동작하지 않습니다:**
+> [!IMPORTANT]
+> **서버 로그인이 깨져 있습니다 (2026-06~)** — 최근 KakaoTalk macOS 빌드 변경으로 `login --save`/`login --manual` 경로가 대부분 동작하지 않습니다.
 > - `login --save` — 최신 빌드는 인증 토큰을 캐시에 남기지 않아 추출이 불가능합니다. ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15))
 > - `login --manual` — 처음 보는 기기는 `status=-100`(기기 미등록)을 받는데, 현재 macOS 앱에는 자동 기기 등록(passcode) 엔드포인트가 없어(404) 로그인을 완료할 수 없습니다. ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22))
 >
 > **🚨 미등록 기기로 로그인을 반복 시도하지 마세요.** 카카오가 계정의 "서브 디바이스 로그인"을 차단하거나 계정을 제재할 수 있습니다(실제 피해 사례가 보고되었습니다).
 >
-> 서버 통신 없이 비교적 안전하게 쓰려면 `local-*` 명령(로컬 DB 읽기 전용)만 사용하세요.
+> **하지만 로그인 없이도 CLI는 완전히 동작합니다.** `local-send`/`ax-read`는 macOS Accessibility API로 카카오톡 UI를 직접 읽고 조작해서, 서버 세션 없이도 실제 메시지 전송과 최근 대화 읽기를 모두 지원합니다 (아래 [Quick Start](#quick-start) 참고). 로컬 SQLCipher DB(`local-chats`/`local-read`/`local-search`)는 최신 카카오톡 빌드에서 키 유도 공식이 어긋나 있어 현재 신뢰할 수 없습니다.
 
 > [!WARNING]
 > 이 프로젝트는 카카오(Kakao Corp.)와 무관한 비공식 CLI입니다. 연구, 자동화, 로컬 워크플로 용도로 만들었고, 카카오의 승인이나 보증을 받지 않았습니다.
@@ -68,16 +66,33 @@
 
 ## Quick Start
 
-### For Human
+### 로그인 없이 쓰기 (권장)
+
+서버 로그인이 필요 없는 경로입니다. KakaoTalk 앱이 실행 중이고 로그인되어 있기만 하면 됩니다.
 
 ```bash
 # Homebrew
 brew tap JungHoonGhae/openkakao
 brew install openkakao-cli
 
-# 1. 인증 정보 저장
-#    최신 KakaoTalk은 토큰을 캐시에 남기지 않으므로 이메일+비번 로그인을 권장합니다 (#15)
-#    처음 보는 기기면 KakaoTalk이 인증번호(passcode)를 보내며, CLI가 입력을 받아 기기 등록을 마칩니다 (#20)
+# 1. 실제 전송 전 화이트리스트에 채팅방을 등록 (필수 — 아무 채팅에나 보내지 않도록)
+#    ~/.config/openkakao/config.toml
+#    [safety]
+#    allow_ax_send = true
+#    allowed_send_chats = ["나와의 채팅에 표시되는 이름"]
+
+# 2. 메시지 보내기 — 서버 접촉 없음, 실제 카톡 UI를 직접 조작
+openkakao-cli local-send "채팅방 표시 이름" "Hello from CLI!" --dry-run   # 미리보기
+openkakao-cli local-send "채팅방 표시 이름" "Hello from CLI!" -y         # 실제 전송
+
+# 3. 최근 메시지 읽기 — 같은 방식(AX)으로 화면에 보이는 메시지를 스크랩
+openkakao-cli ax-read "채팅방 표시 이름" -n 20
+```
+
+### 서버 로그인 기반 (현재 대부분 깨짐)
+
+```bash
+# 1. 인증 정보 저장 — 최신 빌드에서는 대부분 실패합니다 (#15, #20, #22)
 openkakao-cli login --manual --save
 #    (예전 빌드에서 캐시 추출이 되는 경우: openkakao-cli login --save)
 
@@ -90,7 +105,7 @@ openkakao-cli read <chat_id> -n 20
 # 4. 메시지 보내기 (LOCO write — opt-in 필요: safety.allow_loco_write = true)
 openkakao-cli send <chat_id> "Hello from CLI!"
 
-# 안전한 로컬 읽기 대안 (서버 통신 없음)
+# 로컬 DB 읽기 (현재 최신 빌드에서 키 유도 실패로 신뢰 불가 — ax-read 권장)
 openkakao-cli local-chats
 openkakao-cli local-read <chat_id>
 ```
@@ -106,9 +121,9 @@ openkakao-cli members <chat_id> --rest
 ### For Agent
 
 ```bash
-# 안전한 로컬 DB 읽기 (서버 통신 없음)
-openkakao-cli local-chats --json
-openkakao-cli local-read <chat_id> --json
+# 로그인 없이 읽고 쓰기 (서버 통신 없음, AX 기반)
+openkakao-cli ax-read "채팅방 표시 이름" -n 20 --json
+openkakao-cli local-send "채팅방 표시 이름" "message" -y --json
 
 # 실행 전 미리보기
 openkakao-cli send <chat_id> "message" --dry-run --json
@@ -133,16 +148,18 @@ npx skills add JungHoonGhae/skills@openkakao-cli
 
 ## 핵심
 
+- `local-send`/`ax-read`로 **로그인 없이** 실제 메시지 전송·읽기 (macOS Accessibility API로 카톡 UI를 직접 조작, 서버 통신 없음)
 - macOS 카카오톡 앱에서 인증 정보 추출
 - 채팅, 메시지, 멤버, 친구, 프로필 조회
 - LOCO 기반 메시지 전송, 실시간 watch, 미디어 처리
 - `--json` 출력으로 `jq`, `cron`, SQLite, LLM 흐름과 연결 가능
 - `watch`, `hook`, `webhook`로 로컬 자동화와 에이전트 워크플로에 연결 가능
 - `friends --local`, `profile --local`, `profile --chat-id`로 일부 조회 복구 가능
-- `local-chats`, `local-read`, `local-search`로 로컬 DB에서 안전하게 읽기 (서버 통신 없음)
+- `local-chats`, `local-read`, `local-search`로 로컬 DB 읽기 시도 (최신 빌드에서는 키 유도 실패로 신뢰 불가 — `ax-read` 권장)
 - `--dry-run`으로 실행 전 미리보기
 - `send --me`로 나와의 채팅에 바로 전송 (테스트용)
 - LOCO write 기본 비활성 — `safety.allow_loco_write = true`로 opt-in
+- `local-send`도 기본 비활성 — `safety.allow_ax_send = true` + `safety.allowed_send_chats` 화이트리스트로 opt-in
 
 ## 이런 경우에 잘 맞습니다
 
@@ -162,16 +179,27 @@ v1.1.0부터 LOCO write 작업(send, delete, edit, react)은 **기본 비활성*
 allow_loco_write = true
 ```
 
+`local-send`(AX 기반 실전송)도 v1.4.0부터 기본 비활성이며, 별도로 opt-in과 **채팅방 화이트리스트**가 필요합니다. `local-send`는 채팅 목록에서 표시 이름이 정확히 일치하는 방을 찾아 전송하는데, 로컬 DB의 chat-id로 대상을 다시 검증할 방법이 없어졌기 때문에 화이트리스트가 유일한 안전장치입니다:
+
+```toml
+# ~/.config/openkakao/config.toml
+[safety]
+allow_ax_send = true
+allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 채팅방 이름"]
+```
+
 읽기 전용 작업은 항상 사용 가능합니다:
 
 | 명령 | 설명 | 서버 통신 |
 |------|------|-----------|
-| `local-chats` | 로컬 DB 채팅 목록 | 없음 |
-| `local-read <id>` | 로컬 DB 메시지 읽기 | 없음 |
-| `local-search "keyword"` | 로컬 DB 검색 | 없음 |
+| `ax-read <chat_name>` | 화면에 열린 채팅의 최근 메시지 스크랩 (AX) | 없음 |
+| `local-chats` | 로컬 DB 채팅 목록 (최신 빌드에서 신뢰 불가) | 없음 |
+| `local-read <id>` | 로컬 DB 메시지 읽기 (최신 빌드에서 신뢰 불가) | 없음 |
+| `local-search "keyword"` | 로컬 DB 검색 (최신 빌드에서 신뢰 불가) | 없음 |
 | `chats --rest` | REST API 채팅 목록 | REST |
 | `read <id> --rest` | REST API 메시지 읽기 | REST |
 | `send ... --dry-run` | 전송 미리보기 | 없음 |
+| `local-send ... --dry-run` | AX 전송 미리보기 | 없음 |
 
 ## 요구 사항
 
@@ -241,6 +269,11 @@ cargo build --release
 ## Contributing
 
 버그 제보와 PR 환영합니다.
+
+## Acknowledgments
+
+- [kakaocli](https://github.com/silver-flight-group/kakaocli) (MIT) — `local-send`의 macOS Accessibility API 기반 카톡 UI 자동 조작(채팅방 행 선택, 입력창 탐색·전송) 로직을 Rust로 이식했습니다 (`src/ax_send.rs`).
+- [Peekaboo](https://github.com/steipete/Peekaboo) (MIT) — `local-send`에서 `CGEventPostToPid`로 이벤트를 대상 프로세스에 직접 전달하는 방식을 참고해, kakaocli가 겪던 포그라운드 활성화 타이밍 레이스([silver-flight-group/kakaocli#9](https://github.com/silver-flight-group/kakaocli/issues/9))를 우회했습니다.
 
 ## License
 

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -1,0 +1,442 @@
+//! AX-automation-based message sending.
+//!
+//! Drives the real KakaoTalk macOS UI via the Accessibility API instead of
+//! the LOCO protocol, so it works even though server login (`-100`) and
+//! LOCO auth are broken (see README deprecation notice). No network or
+//! KakaoTalk-server contact happens anywhere in this module.
+//!
+//! Ported from the sibling Swift project kakaocli
+//! (https://github.com/silver-flight-group/kakaocli, MIT), with one
+//! reliability fix borrowed from steipete's Peekaboo
+//! (https://github.com/openclaw/Peekaboo): key/click events are posted
+//! directly to KakaoTalk's pid via `CGEventPostToPid` instead of first
+//! activating the app to the foreground, which avoids the focus-timing
+//! race that causes kakaocli's `send` to hang
+//! (https://github.com/silver-flight-group/kakaocli/issues/9).
+
+use std::process::Command;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use accessibility::{AXAttribute, AXUIElement, AXUIElementAttributes};
+use accessibility_sys::kAXPressAction;
+use anyhow::{anyhow, Context, Result};
+use core_foundation::array::CFArray;
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::string::CFString;
+use core_graphics::event::CGEvent;
+use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+
+const KAKAOTALK_BUNDLE_ID: &str = "com.kakao.KakaoTalkMac";
+const RETURN_KEYCODE: u16 = 36;
+const OPEN_CHAT_TIMEOUT: Duration = Duration::from_secs(5);
+const VERIFY_TIMEOUT: Duration = Duration::from_secs(10);
+const VERIFY_POLL_INTERVAL: Duration = Duration::from_millis(400);
+
+/// Find the running KakaoTalk process id via `pgrep -x`.
+///
+/// We shell out rather than link `NSRunningApplication`/AppKit bindings
+/// because this is the only place we need a pid lookup and it keeps the
+/// dependency surface small (matches `local_db.rs`'s existing convention of
+/// shelling out to `ioreg` for platform info).
+pub fn find_kakaotalk_pid() -> Result<i32> {
+    let output = Command::new("pgrep")
+        .args(["-x", "KakaoTalk"])
+        .output()
+        .context("failed to run pgrep")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .next()
+        .and_then(|line| line.trim().parse::<i32>().ok())
+        .ok_or_else(|| {
+            anyhow!("KakaoTalk is not running (or `{KAKAOTALK_BUNDLE_ID}` not found) — open it and log in first")
+        })
+}
+
+fn children(el: &AXUIElement) -> Result<Vec<AXUIElement>> {
+    let arr = el
+        .children()
+        .map_err(|e| anyhow!("AXChildren read failed: {e:?}"))?;
+    Ok(arr.iter().map(|e| e.clone()).collect())
+}
+
+fn role(el: &AXUIElement) -> String {
+    el.role().map(|s| s.to_string()).unwrap_or_default()
+}
+
+/// Read an element's `AXValue` as a string (works for `AXStaticText` and
+/// `AXTextArea`; other value types just fail the downcast and are skipped).
+fn value_as_string(el: &AXUIElement) -> Option<String> {
+    el.value().ok().and_then(|v| v.downcast::<CFString>()).map(|s| s.to_string())
+}
+
+/// Read a string attribute by raw name (works for attributes with no typed
+/// accessor in the `accessibility` crate, e.g. `AXIdentifier`).
+fn attr_as_string(el: &AXUIElement, name: &str) -> Option<String> {
+    let attr: AXAttribute<CFType> = AXAttribute::new(&CFString::new(name));
+    el.attribute(&attr)
+        .ok()
+        .and_then(|v| v.downcast::<CFString>())
+        .map(|s| s.to_string())
+}
+
+/// Find KakaoTalk's main chat-list window, as opposed to any individual
+/// open-chat windows (which are separate `AXWindow`s titled with the
+/// other party's — or your own, for the self chat — display name).
+fn find_main_window(app: &AXUIElement) -> Result<AXUIElement> {
+    let windows = app
+        .windows()
+        .map_err(|e| anyhow!("AXWindows read failed: {e:?}"))?;
+    windows
+        .iter()
+        .find(|w| attr_as_string(w, "AXIdentifier").as_deref() == Some("Main Window"))
+        .map(|w| w.clone())
+        .ok_or_else(|| anyhow!("could not find KakaoTalk's main chat-list window — is it open?"))
+}
+
+fn find_descendants_by_role(root: &AXUIElement, target_role: &str, out: &mut Vec<AXUIElement>) {
+    if role(root) == target_role {
+        out.push(root.clone());
+    }
+    if let Ok(kids) = children(root) {
+        for kid in kids {
+            find_descendants_by_role(&kid, target_role, out);
+        }
+    }
+}
+
+/// Post a CGEvent to KakaoTalk's pid directly (no `activate()` foreground
+/// switch — this is the Peekaboo-style fix for the focus race that hangs
+/// kakaocli's send path).
+fn post_key_to_pid(pid: i32, keycode: u16, key_down: bool) -> Result<()> {
+    let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
+        .map_err(|_| anyhow!("failed to create CGEventSource"))?;
+    let event = CGEvent::new_keyboard_event(source, keycode, key_down)
+        .map_err(|_| anyhow!("failed to create keyboard CGEvent"))?;
+    event.post_to_pid(pid);
+    Ok(())
+}
+
+fn press_return(pid: i32) -> Result<()> {
+    post_key_to_pid(pid, RETURN_KEYCODE, true)?;
+    post_key_to_pid(pid, RETURN_KEYCODE, false)?;
+    Ok(())
+}
+
+/// Type `text` into the focused field by posting one keyboard CGEvent pair
+/// per character directly to KakaoTalk's pid, using the Unicode string
+/// payload (`CGEventKeyboardSetUnicodeString`) so Hangul input works without
+/// needing per-character keycode mapping.
+fn type_text_to_pid(pid: i32, text: &str) -> Result<()> {
+    let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
+        .map_err(|_| anyhow!("failed to create CGEventSource"))?;
+    for down in [true, false] {
+        let event = CGEvent::new_keyboard_event(source.clone(), 0, down)
+            .map_err(|_| anyhow!("failed to create keyboard CGEvent"))?;
+        let utf16: Vec<u16> = text.encode_utf16().collect();
+        event.set_string_from_utf16_unchecked(&utf16);
+        event.post_to_pid(pid);
+    }
+    Ok(())
+}
+
+/// Switch the main window to the chat-list ("chatrooms") tab if it isn't
+/// already there — the chat-list `AXTable` only exists while that tab is
+/// active; the Friends tab renders an `AXOutline` instead. Left over from an
+/// earlier manual tab switch during development, this makes `open_chat_row`
+/// resilient to whatever tab the window happens to be on.
+fn ensure_chatrooms_tab(main_window: &AXUIElement) {
+    let mut tables = Vec::new();
+    find_descendants_by_role(main_window, "AXTable", &mut tables);
+    if !tables.is_empty() {
+        return;
+    }
+    let mut buttons = Vec::new();
+    find_descendants_by_role(main_window, "AXButton", &mut buttons);
+    if let Some(tab) = buttons
+        .iter()
+        .find(|b| attr_as_string(b, "AXIdentifier").as_deref() == Some("chatrooms"))
+    {
+        let _ = tab.perform_action(&CFString::new(kAXPressAction));
+        sleep(Duration::from_millis(400));
+    }
+}
+
+fn open_chat_row(app: &AXUIElement, chat_display_name: &str) -> Result<()> {
+    let main_window = find_main_window(app)?;
+    ensure_chatrooms_tab(&main_window);
+    let mut tables = Vec::new();
+    find_descendants_by_role(&main_window, "AXTable", &mut tables);
+    let table = tables
+        .first()
+        .ok_or_else(|| anyhow!("could not find chat list table in KakaoTalk's AX tree"))?;
+
+    let mut rows = Vec::new();
+    find_descendants_by_role(table, "AXRow", &mut rows);
+
+    // Match on the row's first AXStaticText (the chat name) exactly, not a
+    // substring — "정훈" must not accidentally match a "정훈 & 프리" group
+    // chat. If more than one row has the exact same display name, refuse to
+    // guess rather than silently picking one (there is no chat-id to
+    // disambiguate with — see SafetyConfig::allowed_send_chats).
+    let mut matches = Vec::new();
+    for row in &rows {
+        let mut texts = Vec::new();
+        find_descendants_by_role(row, "AXStaticText", &mut texts);
+        if texts.first().and_then(value_as_string).as_deref() == Some(chat_display_name) {
+            matches.push(row);
+        }
+    }
+
+    let row = match matches.as_slice() {
+        [] => {
+            return Err(anyhow!(
+                "chat '{chat_display_name}' not found in visible/loaded chat list"
+            ))
+        }
+        [only] => *only,
+        _ => {
+            return Err(anyhow!(
+                "chat name '{chat_display_name}' matches {} chats in the visible list — ambiguous, refusing to guess",
+                matches.len()
+            ))
+        }
+    };
+
+    // Select via AX attribute (works even for off-screen rows — this is the
+    // fix kakaocli landed for its off-screen-row regression) rather than a
+    // coordinate-based double click. `AXSelectedRows` is a settable
+    // attribute of the *table*, not the row (has no typed accessor in the
+    // `accessibility` crate either way, so it's addressed by raw name).
+    let selected_rows_attr: AXAttribute<CFType> =
+        AXAttribute::new(&CFString::new("AXSelectedRows"));
+    let one_row = CFArray::from_CFTypes(std::slice::from_ref(row));
+    table
+        .set_attribute(&selected_rows_attr, one_row.as_CFType())
+        .map_err(|e| anyhow!("failed to select chat row: {e:?}"))?;
+
+    Ok(())
+}
+
+/// Search a single root (a window, or the whole app as a fallback) for the
+/// message composer: an `AXScrollArea` that wraps an `AXTextArea` but no
+/// `AXTable` (which would make it the message list instead).
+fn find_input_field_in(root: &AXUIElement) -> Option<AXUIElement> {
+    let mut scroll_areas = Vec::new();
+    find_descendants_by_role(root, "AXScrollArea", &mut scroll_areas);
+
+    for area in scroll_areas {
+        let mut tables = Vec::new();
+        find_descendants_by_role(&area, "AXTable", &mut tables);
+        if !tables.is_empty() {
+            continue; // this scroll area is the message list, not the composer
+        }
+        let mut text_areas = Vec::new();
+        find_descendants_by_role(&area, "AXTextArea", &mut text_areas);
+        if let Some(field) = text_areas.into_iter().next() {
+            return Some(field);
+        }
+    }
+    None
+}
+
+/// Find the composer field, preferring the chat window whose title matches
+/// `chat_display_name` (relevant when more than one chat window is already
+/// open) and falling back to a whole-app search otherwise.
+fn find_input_field(app: &AXUIElement, chat_display_name: &str) -> Result<AXUIElement> {
+    if let Ok(windows) = app.windows() {
+        if let Some(window) = windows.iter().find(|w| {
+            w.title()
+                .map(|t| t.to_string())
+                .ok()
+                .is_some_and(|t| t.contains(chat_display_name))
+        }) {
+            if let Some(field) = find_input_field_in(&window) {
+                return Ok(field);
+            }
+        }
+    }
+    find_input_field_in(app).ok_or_else(|| {
+        anyhow!("could not find the message input field — is the chat window open and focused?")
+    })
+}
+
+/// One message bubble scraped from a chat window's AX message list.
+#[derive(Debug, Clone)]
+pub struct AxMessage {
+    /// The time label's `AXHelp` text (full date, e.g. "2026. 6. 17.") if
+    /// present, else its plain displayed value (e.g. "14:32").
+    pub time: Option<String>,
+    pub text: String,
+}
+
+/// Scrape every message bubble currently rendered in a chat window's message
+/// list, in on-screen (chronological) order. Rows with no `AXTextArea`
+/// (date separators, system notices) are skipped.
+fn read_visible_messages(window: &AXUIElement) -> Vec<AxMessage> {
+    let mut tables = Vec::new();
+    find_descendants_by_role(window, "AXTable", &mut tables);
+    let Some(table) = tables.first() else {
+        return Vec::new();
+    };
+    let mut rows = Vec::new();
+    find_descendants_by_role(table, "AXRow", &mut rows);
+
+    rows.iter()
+        .filter_map(|row| {
+            let mut text_areas = Vec::new();
+            find_descendants_by_role(row, "AXTextArea", &mut text_areas);
+            let text = text_areas.first().and_then(value_as_string)?;
+
+            let mut static_texts = Vec::new();
+            find_descendants_by_role(row, "AXStaticText", &mut static_texts);
+            let time = static_texts
+                .first()
+                .and_then(|t| attr_as_string(t, "AXHelp").or_else(|| value_as_string(t)));
+
+            Some(AxMessage { time, text })
+        })
+        .collect()
+}
+
+/// Scrape the text of every message bubble currently rendered in a chat
+/// window's message list, in on-screen (chronological) order.
+fn read_visible_message_texts(window: &AXUIElement) -> Vec<String> {
+    read_visible_messages(window).into_iter().map(|m| m.text).collect()
+}
+
+/// Find an already-open chat window whose title matches `chat_display_name`
+/// (the other party's — or your own, for the self/memo chat — display name).
+fn find_chat_window(app: &AXUIElement, chat_display_name: &str) -> Option<AXUIElement> {
+    app.windows()
+        .ok()?
+        .iter()
+        .find(|w| {
+            w.title()
+                .map(|t| t.to_string())
+                .ok()
+                .is_some_and(|t| t.contains(chat_display_name))
+        })
+        .map(|w| w.clone())
+}
+
+/// Read the most recent `count` messages visible in a chat's AX message list,
+/// opening the chat first if it isn't already open. No local SQLCipher DB
+/// access, so this works even when `local_db.rs`'s key derivation is stale
+/// for the installed KakaoTalk build (see README deprecation notice). Only
+/// messages already rendered on screen are returned — older history requires
+/// scrolling up in KakaoTalk first.
+pub fn read_via_ax(chat_display_name: &str, count: usize) -> Result<Vec<AxMessage>> {
+    let pid = find_kakaotalk_pid()?;
+    let app = AXUIElement::application(pid);
+
+    open_chat_row(&app, chat_display_name)?;
+    press_return(pid)?;
+
+    let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
+    let window = loop {
+        if let Some(window) = find_chat_window(&app, chat_display_name) {
+            if !read_visible_messages(&window).is_empty() {
+                break window;
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("chat window did not open (or has no visible messages) in time");
+        }
+        sleep(Duration::from_millis(150));
+    };
+
+    let mut messages = read_visible_messages(&window);
+    if messages.len() > count {
+        messages = messages.split_off(messages.len() - count);
+    }
+    Ok(messages)
+}
+
+/// Send `message` to the chat identified by `chat_display_name` via AX
+/// automation, then poll the chat window's own message list (scraped via
+/// AX, not the local SQLCipher DB) to confirm delivery instead of trusting
+/// a fixed sleep.
+///
+/// `chat_display_name` should be a substring of the chat's title as shown
+/// in the chat list (same matching convention as kakaocli's `send`).
+pub fn send_via_ax(chat_display_name: &str, message: &str) -> Result<()> {
+    let pid = find_kakaotalk_pid()?;
+    let app = AXUIElement::application(pid);
+
+    open_chat_row(&app, chat_display_name)?;
+    press_return(pid)?;
+
+    let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
+    let field = loop {
+        match find_input_field(&app, chat_display_name) {
+            Ok(field) => break field,
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    return Err(e.context("chat window did not open in time"));
+                }
+                sleep(Duration::from_millis(150));
+            }
+        }
+    };
+
+    if field.set_value(CFString::new(message).as_CFType()).is_err() {
+        type_text_to_pid(pid, message)?;
+    }
+    press_return(pid)?;
+
+    verify_sent(&app, message, VERIFY_TIMEOUT)
+}
+
+/// Poll every open chat window's AX-scraped message list for `message` to
+/// appear, instead of a fixed sleep+assume-success. Scanning all windows
+/// (rather than matching one by title) sidesteps the fact that a chat
+/// window's title is the *other party's* name (or your own name, for the
+/// self/"나와의 채팅" memo chat) — not necessarily the string used to select
+/// the chat in the list. Needs no extra permission (no Screen Recording,
+/// unlike a screenshot-based verification loop) since it reuses the same
+/// Accessibility access already granted for sending.
+fn verify_sent(app: &AXUIElement, message: &str, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(windows) = app.windows() {
+            if windows
+                .iter()
+                .any(|w| read_visible_message_texts(&w).iter().any(|t| t == message))
+            {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "sent the message but could not confirm it appeared in any open chat window within {}s — check KakaoTalk manually",
+                timeout.as_secs()
+            );
+        }
+        sleep(VERIFY_POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_chat_timeout_is_bounded_and_shorter_than_verify_timeout() {
+        assert!(OPEN_CHAT_TIMEOUT < VERIFY_TIMEOUT);
+        assert!(OPEN_CHAT_TIMEOUT.as_secs() > 0);
+    }
+
+    #[test]
+    fn verify_poll_interval_is_smaller_than_timeout() {
+        assert!(VERIFY_POLL_INTERVAL < VERIFY_TIMEOUT);
+    }
+
+    #[test]
+    fn return_keycode_matches_macos_carbon_constant() {
+        // kVK_Return from Carbon HIToolbox/Events.h — used throughout macOS
+        // AX/CGEvent automation tools (also what kakaocli's AXHelpers uses).
+        assert_eq!(RETURN_KEYCODE, 36);
+    }
+}

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -337,7 +337,7 @@ pub fn cmd_login_manual(
     // macOS builds removed the passcode/register_device REST endpoints (they 404), so
     // there is no automated way to register the device from the CLI. Stop here with a
     // clear warning instead of retrying — repeated logins from an unregistered device
-    // can get the account's sub-device login blocked (#20, #22). DEPRECATED.
+    // can get the account's sub-device login blocked (#20, #22).
     if status == DEVICE_NOT_REGISTERED {
         print_device_not_registered_warning();
         anyhow::bail!("login failed (status=-100, device not registered)");
@@ -388,8 +388,8 @@ fn print_device_not_registered_warning() {
     eprintln!("     can get your account's sub-device login blocked or the account");
     eprintln!("     restricted. This has actually happened to other users.");
     eprintln!();
-    eprintln!("  This project is deprecated and no longer actively maintained.");
-    eprintln!("  For server-free use, the read-only 'local-*' commands still work.");
+    eprintln!("  Server login is unfixed on current KakaoTalk builds — but the CLI still");
+    eprintln!("  works without it: 'local-send'/'ax-read'/'local-chats' need no login at all.");
 }
 
 fn print_manual_login_failure(status: i64, message: &str) {

--- a/src/commands/ax_read.rs
+++ b/src/commands/ax_read.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+
+use crate::ax_send;
+
+pub struct AxReadOptions {
+    pub chat_name: String,
+    pub count: usize,
+    pub json: bool,
+}
+
+/// Read recent messages via AX automation (scrapes the open KakaoTalk chat
+/// window) — no local SQLCipher DB access required. See `src/ax_send.rs`.
+pub fn cmd_ax_read(opts: AxReadOptions) -> Result<()> {
+    let AxReadOptions {
+        ref chat_name,
+        count,
+        json,
+    } = opts;
+
+    let messages = ax_send::read_via_ax(chat_name, count)?;
+
+    if json {
+        let items: Vec<_> = messages
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "time": m.time,
+                    "text": m.text,
+                })
+            })
+            .collect();
+        crate::util::output_json(&serde_json::json!({
+            "chat_name": chat_name,
+            "messages": items,
+        }))?;
+    } else if messages.is_empty() {
+        println!("No visible messages found in chat \"{chat_name}\".");
+    } else {
+        for m in &messages {
+            match &m.time {
+                Some(t) => println!("[{t}] {}", m.text),
+                None => println!("{}", m.text),
+            }
+        }
+        println!("\n{} messages (AX scrape, no server contact)", messages.len());
+    }
+
+    Ok(())
+}

--- a/src/commands/local_send.rs
+++ b/src/commands/local_send.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+
+use crate::ax_send;
+use crate::util::{confirm, truncate, validate_outbound_message};
+
+pub struct LocalSendOptions {
+    pub chat_name: String,
+    pub message: String,
+    pub skip_confirm: bool,
+    pub dry_run: bool,
+    pub json: bool,
+}
+
+/// Send a message via AX automation (drives the real KakaoTalk window) —
+/// no LOCO/REST session and no local SQLCipher DB access required. Both the
+/// chat lookup and the post-send delivery check happen entirely through the
+/// Accessibility tree. See `src/ax_send.rs` for the mechanism.
+pub fn cmd_local_send(opts: LocalSendOptions) -> Result<()> {
+    let LocalSendOptions {
+        ref chat_name,
+        ref message,
+        skip_confirm,
+        dry_run,
+        json,
+    } = opts;
+    validate_outbound_message(message)?;
+
+    if dry_run {
+        eprintln!(
+            "[dry-run] Would AX-send to chat \"{}\": \"{}\"",
+            chat_name,
+            truncate(message, 80)
+        );
+        if json {
+            crate::util::output_json(&serde_json::json!({
+                "dry_run": true,
+                "action": "local_send",
+                "chat_name": chat_name,
+                "message": message,
+            }))?;
+        }
+        return Ok(());
+    }
+
+    if !skip_confirm {
+        eprint!(
+            "AX-send to chat \"{}\"? Message: \"{}\"\n[y/N] ",
+            chat_name,
+            truncate(message, 50)
+        );
+        if !confirm()? {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    ax_send::send_via_ax(chat_name, message)?;
+
+    if json {
+        crate::util::output_json(&serde_json::json!({
+            "chat_name": chat_name,
+            "status": "sent",
+        }))?;
+    } else {
+        println!("Message sent!");
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,10 @@
 pub mod analytics;
 pub mod auth;
+pub mod ax_read;
 pub mod chats;
 pub mod doctor;
 pub mod download;
+pub mod local_send;
 pub mod members;
 pub mod probe;
 pub mod profile;

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,19 @@ pub struct SafetyConfig {
     /// Disabled by default to protect against account bans.
     #[serde(default)]
     pub allow_loco_write: bool,
+    /// Enable AX-automation-based `local-send` (no server contact, drives the
+    /// KakaoTalk UI directly). Disabled by default since it still sends real
+    /// messages from a real KakaoTalk window.
+    #[serde(default)]
+    pub allow_ax_send: bool,
+    /// Chat display names `local-send` is allowed to target. AX-send matches
+    /// chats by display-name text scraped from the UI, not a chat-id (the
+    /// local DB it would normally cross-check against is unreadable on
+    /// current KakaoTalk builds), so an exact-match allowlist is the only
+    /// guard against sending to the wrong chat. Empty means nothing is
+    /// allowed to send.
+    #[serde(default)]
+    pub allowed_send_chats: Vec<String>,
 }
 
 impl Default for SafetyConfig {
@@ -71,6 +84,8 @@ impl Default for SafetyConfig {
             webhook_timeout_secs: Some(10),
             allow_insecure_webhooks: false,
             allow_loco_write: false,
+            allow_ax_send: false,
+            allowed_send_chats: Vec::new(),
         }
     }
 }

--- a/src/local_db.rs
+++ b/src/local_db.rs
@@ -218,6 +218,9 @@ fn recover_user_id_from_sha512(hex_hash: &str) -> Option<i64> {
         hasher.update(i.to_string().as_bytes());
         let result = hasher.finalize();
         if result.as_slice() == target {
+            if std::env::var("OPENKAKAO_CLI_DEBUG").is_ok() {
+                eprintln!("[local-db] SHA-512 preimage found: userId={i}");
+            }
             return Some(i);
         }
         // Check the deadline periodically to keep the hot loop tight.
@@ -427,6 +430,9 @@ impl LocalDbReader {
         let user_id = get_user_id_from_plist().context("Failed to get KakaoTalk user ID")?;
 
         let db_name = derive_database_name(user_id, &uuid);
+        if std::env::var("OPENKAKAO_CLI_DEBUG").is_ok() {
+            eprintln!("[local-db] uuid={uuid} user_id={user_id} derived_db_name={db_name}");
+        }
         let db_path =
             find_database_path(&db_name).context("Failed to locate KakaoTalk local database")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod auth_flow;
+mod ax_send;
 mod commands;
 mod config;
 mod credentials;
@@ -525,6 +526,22 @@ enum Commands {
     },
     /// Show local KakaoTalk database schema
     LocalSchema,
+    /// Send a message via AX automation (no server contact, drives KakaoTalk's UI directly)
+    LocalSend {
+        chat_name: String,
+        message: String,
+        #[arg(long, short = 'y', help = "Skip confirmation prompt")]
+        yes: bool,
+        #[arg(long, help = "Preview the action without executing")]
+        dry_run: bool,
+    },
+    /// Read recent messages via AX automation (no server contact, no local
+    /// DB access — scrapes the open KakaoTalk chat window directly)
+    AxRead {
+        chat_name: String,
+        #[arg(short = 'n', long, default_value_t = 20)]
+        count: usize,
+    },
     /// Run diagnostic checks on KakaoTalk installation and connectivity
     Doctor {
         /// Also test LOCO booking connectivity (makes network request)
@@ -543,6 +560,39 @@ fn require_loco_write(config: &config::OpenKakaoConfig) -> Result<()> {
              [safety]\n\
              allow_loco_write = true\n\n\
              Consider using local-read / local-chats / local-search for safe read-only access."
+        );
+    }
+    Ok(())
+}
+
+fn require_ax_send(config: &config::OpenKakaoConfig) -> Result<()> {
+    if !config.safety.allow_ax_send {
+        anyhow::bail!(
+            "AX-automation send is disabled by default.\n\
+             local-send drives the real KakaoTalk window (types text and hits Enter\n\
+             on your behalf) — treat it with the same care as `send`.\n\n\
+             To enable, add to ~/.config/openkakao/config.toml:\n\n\
+             [safety]\n\
+             allow_ax_send = true\n\n\
+             KakaoTalk must be running and already logged in; no server/LOCO contact is made."
+        );
+    }
+    Ok(())
+}
+
+/// `local-send` has no chat-id to cross-check against (the local DB it would
+/// normally verify with is unreadable on current KakaoTalk builds), so an
+/// exact-match allowlist in config is the only guard against typos or
+/// substring collisions sending to the wrong chat.
+fn require_allowed_send_chat(config: &config::OpenKakaoConfig, chat_name: &str) -> Result<()> {
+    if !config.safety.allowed_send_chats.iter().any(|c| c == chat_name) {
+        anyhow::bail!(
+            "chat \"{chat_name}\" is not in the local-send allowlist.\n\n\
+             local-send matches chats by display-name text scraped from the KakaoTalk UI,\n\
+             not a chat-id, so an explicit allowlist is required to avoid sending to the\n\
+             wrong chat. Add to ~/.config/openkakao/config.toml:\n\n\
+             [safety]\n\
+             allowed_send_chats = [\"{chat_name}\"]"
         );
     }
     Ok(())
@@ -576,14 +626,16 @@ fn main() -> Result<()> {
         NO_COLOR.store(true, Ordering::Relaxed);
     }
 
-    // Deprecation notice — printed to stderr so it never corrupts JSON on stdout.
-    // Silenced with OPENKAKAO_CLI_NO_DEPRECATION=1 for scripted local-only use.
+    // Server-login warning — printed to stderr so it never corrupts JSON on
+    // stdout. Silenced with OPENKAKAO_CLI_NO_DEPRECATION=1 for scripted
+    // local-only use. `local-send`/`ax-read` need neither login nor this
+    // warning, since they never touch Kakao's servers.
     if std::env::var_os("OPENKAKAO_CLI_NO_DEPRECATION").is_none() {
-        eprintln!("⚠️  openkakao-cli is DEPRECATED and no longer actively maintained.");
-        eprintln!("   Login is broken on recent KakaoTalk macOS builds. Do NOT repeatedly retry");
-        eprintln!("   login on an unregistered device — it can get your account's sub-device");
+        eprintln!("⚠️  Server login (login --save / login --manual) is broken on recent");
+        eprintln!("   KakaoTalk macOS builds. Do NOT repeatedly retry login on an unregistered");
+        eprintln!("   device — it can get your account's sub-device login blocked. Prefer");
         eprintln!(
-            "   login blocked. Read-only 'local-*' commands are the safest path. See README."
+            "   'local-send'/'ax-read'/'local-chats' — no server contact needed. See README."
         );
     }
 
@@ -1175,6 +1227,32 @@ fn main() -> Result<()> {
                     println!("{}\n", sql);
                 }
             }
+        }
+        Commands::LocalSend {
+            chat_name,
+            message,
+            yes,
+            dry_run,
+        } => {
+            let msg = format_outgoing_message(&message, no_prefix);
+            if !dry_run {
+                require_ax_send(&config)?;
+                require_allowed_send_chat(&config, &chat_name)?;
+            }
+            commands::local_send::cmd_local_send(commands::local_send::LocalSendOptions {
+                chat_name,
+                message: msg,
+                skip_confirm: yes,
+                dry_run,
+                json,
+            })?
+        }
+        Commands::AxRead { chat_name, count } => {
+            commands::ax_read::cmd_ax_read(commands::ax_read::AxReadOptions {
+                chat_name,
+                count,
+                json,
+            })?
         }
         Commands::WatchCache { interval } => commands::auth::cmd_watch_cache(interval)?,
         Commands::Doctor { loco } => commands::doctor::cmd_doctor(json, loco, &config)?,
@@ -2241,10 +2319,44 @@ mod tests {
     }
 
     #[test]
+    fn local_send_command_parses() {
+        let cli = Cli::try_parse_from(["openkakao-cli", "local-send", "나와의 채팅", "hi", "-y"])
+            .expect("local-send should parse");
+        match cli.command {
+            Commands::LocalSend {
+                chat_name,
+                message,
+                yes,
+                dry_run,
+            } => {
+                assert_eq!(chat_name, "나와의 채팅");
+                assert_eq!(message, "hi");
+                assert!(yes);
+                assert!(!dry_run);
+            }
+            other => panic!("expected local-send, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn loco_write_disabled_by_default() {
         let config = crate::config::OpenKakaoConfig::default();
         assert!(!config.safety.allow_loco_write);
         assert!(require_loco_write(&config).is_err());
+    }
+
+    #[test]
+    fn ax_send_disabled_by_default() {
+        let config = crate::config::OpenKakaoConfig::default();
+        assert!(!config.safety.allow_ax_send);
+        assert!(require_ax_send(&config).is_err());
+    }
+
+    #[test]
+    fn ax_send_enabled_when_configured() {
+        let mut config = crate::config::OpenKakaoConfig::default();
+        config.safety.allow_ax_send = true;
+        assert!(require_ax_send(&config).is_ok());
     }
 
     #[test]

--- a/website/content/docs/cli/local-db.mdx
+++ b/website/content/docs/cli/local-db.mdx
@@ -7,6 +7,10 @@ description: Read KakaoTalk data from the local encrypted database with zero ser
   All local-db commands read the encrypted KakaoTalk SQLite database directly on your Mac. No network requests are made, so there is zero risk of account detection or suspension.
 </Callout>
 
+<Callout type="warn" title="Unreliable on current KakaoTalk builds">
+  The key-derivation formula below has drifted from what recent KakaoTalk macOS builds actually use, so decrypting the database currently fails even when the user ID and device UUID are recovered correctly. For login-free reading right now, use [`ax-read`](/docs/cli/local-send) instead — it scrapes the open chat window via the Accessibility API rather than the database.
+</Callout>
+
 ## How it works
 
 KakaoTalk for macOS stores a SQLCipher-encrypted SQLite database locally. OpenKakao derives the decryption key from your device UUID and Kakao user ID using PBKDF2-HMAC-SHA256, then opens the database in **read-only mode**.

--- a/website/content/docs/cli/local-send.mdx
+++ b/website/content/docs/cli/local-send.mdx
@@ -1,0 +1,102 @@
+---
+title: local-send / ax-read
+description: Send and read real messages without a server session, by driving the KakaoTalk UI directly.
+---
+
+<Callout title="No server contact, no local DB dependency">
+  `local-send` and `ax-read` drive the real KakaoTalk macOS app through the Accessibility (AX) API — selecting a chat row, typing into the composer, and reading rendered message bubbles. Neither one talks to Kakao's servers or the local SQLCipher database. This is why they keep working even while [server login is broken](/docs/getting-started/authentication) and the [local DB is unreliable](/docs/cli/local-db) on current KakaoTalk builds.
+</Callout>
+
+## How it works
+
+Both commands find the target chat by its **exact display name**, the same text shown in KakaoTalk's chat list — not a chat-id. There is no local database to cross-check the target against anymore, so:
+
+- Matching is exact, not substring — a search for `"정훈"` will not accidentally match a `"정훈 & 프리"` group chat.
+- If more than one visible chat shares the exact same display name, both commands refuse to guess and return an error.
+- `local-send` additionally requires the chat to be listed in a config allowlist before it will send for real (see [Safety](#safety) below).
+
+Requirements:
+- KakaoTalk.app installed, running, and already logged in on this Mac
+- Accessibility permission granted to your terminal (System Settings → Privacy & Security → Accessibility)
+
+## local-send
+
+```bash
+openkakao-cli local-send <chat_name> <message> [OPTIONS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-y, --yes` | Skip the confirmation prompt |
+| `--dry-run` | Preview the action without sending |
+| `--json` | Output as JSON (global flag) |
+
+```bash
+# Preview first
+openkakao-cli local-send "chat display name" "Hello from CLI!" --dry-run
+
+# Actually send
+openkakao-cli local-send "chat display name" "Hello from CLI!" -y
+```
+
+After typing the message and pressing Enter, `local-send` polls the chat window's own message list (scraped via AX, the same mechanism as `ax-read`) to confirm the message actually appeared, instead of trusting a fixed sleep.
+
+## ax-read
+
+```bash
+openkakao-cli ax-read <chat_name> [OPTIONS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n, --count <N>` | Max messages to return (default: 20) |
+| `--json` | Output as JSON (global flag) |
+
+```bash
+openkakao-cli ax-read "chat display name" -n 20
+openkakao-cli ax-read "chat display name" --json
+```
+
+<Callout type="warn" title="Only what's on screen">
+  `ax-read` returns messages already rendered in the chat window. It does not scroll for you — if you need older history, scroll up in KakaoTalk first, then re-run the command.
+</Callout>
+
+## Safety
+
+`local-send` is disabled by default and needs two things enabled in `~/.config/openkakao/config.toml`:
+
+```toml
+[safety]
+allow_ax_send = true
+allowed_send_chats = ["chat display name you want to allow"]
+```
+
+- `allow_ax_send` — the general opt-in, since `local-send` types text and hits Enter in a real KakaoTalk window on your behalf.
+- `allowed_send_chats` — an **exact-match allowlist**. Because there is no chat-id to verify the send target against, this is the only guard against a typo or a display-name collision sending to the wrong chat. A chat not on this list is rejected before anything is typed.
+
+Both checks are skipped for `--dry-run`, so you can preview against any chat name without touching config.
+
+`ax-read` has no equivalent gate — it only reads what's already rendered on screen, so there's nothing to protect against beyond the exact-match/ambiguity check both commands share.
+
+## When to use this vs local DB vs LOCO
+
+| Scenario | Recommended |
+|----------|-------------|
+| Send a real message, server login broken | `local-send` |
+| Read what's currently visible in a chat, server login broken | `ax-read` |
+| Full message history, server login working | `read` (LOCO) |
+| Full message history, server login broken | not currently available — `ax-read` only sees what's rendered |
+
+## Next
+
+<Cards>
+  <Card title="Local Database" href="/docs/cli/local-db">
+    Why the local-DB read path is currently unreliable.
+  </Card>
+  <Card title="send" href="/docs/cli/send">
+    The LOCO-based send path, for when server login works.
+  </Card>
+  <Card title="Troubleshooting" href="/docs/getting-started/troubleshooting">
+    Common failure modes, including the current login breakage.
+  </Card>
+</Cards>

--- a/website/content/docs/cli/meta.json
+++ b/website/content/docs/cli/meta.json
@@ -10,6 +10,8 @@
     "auth",
     "profile",
     "friends",
+    "---AX Automation (Login-free)---",
+    "local-send",
     "---Local Database---",
     "local-db",
     "---Chats & Messages---",

--- a/website/content/docs/cli/overview.mdx
+++ b/website/content/docs/cli/overview.mdx
@@ -81,10 +81,16 @@ Persistent policy can be stored in [Configuration](/docs/getting-started/configu
 | `relogin` | Refresh token via login.json |
 | `renew` | Renew token via refresh_token |
 
-### Local Database (Safe)
+### AX Automation (Login-free)
 | Command | Description |
 |---------|-------------|
-| `local-chats` | List chats from local KakaoTalk DB (no server contact) |
+| `local-send <chat_name> <msg>` | Send a real message by driving the KakaoTalk UI directly (requires `allow_ax_send` + `allowed_send_chats`, supports `--dry-run`) |
+| `ax-read <chat_name>` | Read the most recently visible messages in a chat via the same UI-scraping mechanism |
+
+### Local Database (currently unreliable)
+| Command | Description |
+|---------|-------------|
+| `local-chats` | List chats from local KakaoTalk DB (no server contact; key derivation is stale on current builds) |
 | `local-read <chat_id>` | Read messages from local DB |
 | `local-search <query>` | Search messages in local DB |
 | `local-schema` | Show local DB schema |

--- a/website/content/docs/getting-started/authentication.mdx
+++ b/website/content/docs/getting-started/authentication.mdx
@@ -5,10 +5,10 @@ description: How OpenKakao authenticates, how recovery policy works, and where u
 
 # Authentication
 
-<Callout type="warn" title="Deprecated — login does not work on recent KakaoTalk builds">
-As of 2026-06 this project is no longer actively maintained, and the login flows below are broken on current KakaoTalk macOS builds. `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)); `login --manual` returns `status=-100` (device not registered) and there is no working device-registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
+<Callout type="warn" title="Login is broken on recent KakaoTalk builds">
+As of 2026-06 the login flows below are broken on current KakaoTalk macOS builds. `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)); `login --manual` returns `status=-100` (device not registered) and there is no working device-registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
 
-**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** The read-only `local-*` commands still work without authenticating to Kakao's servers.
+**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** Neither of the pages below is required for [`local-send`/`ax-read`](/docs/cli/local-send), which never authenticate to Kakao's servers at all.
 </Callout>
 
 OpenKakao derives authentication material from the running KakaoTalk macOS app and stores reusable credentials locally only when you ask it to.

--- a/website/content/docs/getting-started/quickstart.mdx
+++ b/website/content/docs/getting-started/quickstart.mdx
@@ -6,9 +6,40 @@ icon: Rocket
 
 import { KeyRound, ListTree, MessageSquareText, Terminal } from 'lucide-react';
 
-<Callout type="warn" title="Deprecated — authentication is broken (2026-06)">
-This project is no longer actively maintained, and login no longer works on recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The "Authenticate once" step below will fail. **Do not repeatedly retry login — it can get your account's sub-device login blocked.** Only the read-only `local-*` commands still work.
+<Callout type="warn" title="Server login is broken (2026-06~)">
+Login no longer works on recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The "Authenticate once" step below will fail. **Do not repeatedly retry login — it can get your account's sub-device login blocked.**
+
+You don't need login at all to send or read messages: skip straight to [Login-free path](#login-free-path) below. `local-send`/`ax-read` drive the KakaoTalk UI directly via the Accessibility API.
 </Callout>
+
+## Login-free path
+
+No server session required — just KakaoTalk running and already logged in on this Mac.
+
+```bash
+brew tap JungHoonGhae/openkakao
+brew install openkakao-cli
+```
+
+Allowlist the chat you intend to send to (required before any real send — `local-send` has no chat-id to cross-check against, so this is the only guard against sending to the wrong chat):
+
+```toml
+# ~/.config/openkakao/config.toml
+[safety]
+allow_ax_send = true
+allowed_send_chats = ["the exact display name shown in your chat list"]
+```
+
+```bash
+# Read the most recently visible messages in a chat
+openkakao-cli ax-read "chat display name" -n 20
+
+# Preview a send, then actually send it
+openkakao-cli local-send "chat display name" "Hello from CLI!" --dry-run
+openkakao-cli local-send "chat display name" "Hello from CLI!" -y
+```
+
+See [local-send / ax-read](/docs/cli/local-send) for the full reference. The rest of this page covers the server-login path, which is currently broken on most KakaoTalk builds.
 
 ## Introduction
 

--- a/website/content/docs/getting-started/troubleshooting.mdx
+++ b/website/content/docs/getting-started/troubleshooting.mdx
@@ -5,8 +5,8 @@ description: Common failure modes when login, LOCO, or watch mode do not behave 
 
 # Troubleshooting
 
-<Callout type="warn" title="Deprecated — login is broken on recent KakaoTalk builds (2026-06)">
-This project is no longer actively maintained, and **both login paths below fail on current KakaoTalk macOS builds.** `login --save` can't find a token in the cache, and `login --manual` hits `status=-100` with no working device-registration endpoint. **Do not repeatedly retry `--manual` — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The read-only `local-*` commands still work.
+<Callout type="warn" title="Login is broken on recent KakaoTalk builds (2026-06~)">
+**Both login paths below fail on current KakaoTalk macOS builds.** `login --save` can't find a token in the cache, and `login --manual` hits `status=-100` with no working device-registration endpoint. **Do not repeatedly retry `--manual` — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). [`local-send`/`ax-read`](/docs/cli/local-send) don't need login at all.
 </Callout>
 
 ## KakaoTalk macOS compatibility for `login --save`
@@ -69,7 +69,7 @@ openkakao-cli login --manual --save
 <Callout type="warn" title="This no longer completes on current KakaoTalk builds">
 On recent KakaoTalk macOS builds, logging in from a device the account has not seen before makes `login.json` return `status=-100` (device not registered). The official app once exposed a passcode/`register_device` step to clear this, but those REST endpoints no longer exist on macOS (they return **HTTP 404**, confirmed via binary analysis in [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). v1.3.2 tried to automate the passcode flow; it could not work and was reverted in v1.3.3.
 
-**🚨 Do not keep retrying.** Repeated logins from an unregistered device have gotten real users' accounts' **sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20)). There is no known workaround, and the project is now deprecated. Use the read-only `local-*` commands, which never authenticate to Kakao's servers.
+**🚨 Do not keep retrying.** Repeated logins from an unregistered device have gotten real users' accounts' **sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20)). There is no known workaround for server login — but you don't need one: use [`local-send`/`ax-read`](/docs/cli/local-send), which drive the KakaoTalk UI directly and never authenticate to Kakao's servers.
 </Callout>
 
 ### Writing `credentials.json` by hand

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -5,10 +5,10 @@ description: Developer docs for bringing KakaoTalk into local workflows on macOS
 
 import { Bot, History, Send, ShieldCheck } from 'lucide-react';
 
-<Callout type="warn" title="Deprecated — login is broken on recent KakaoTalk builds (2026-06)">
-This project is no longer actively maintained. Recent KakaoTalk macOS builds broke the login paths: `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)), and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
+<Callout type="warn" title="Server login is broken on recent KakaoTalk builds (2026-06~)">
+Recent KakaoTalk macOS builds broke the login paths: `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)), and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
 
-**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** The read-only `local-*` commands still work.
+**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** You don't need it anyway: [`local-send`/`ax-read`](/docs/cli/local-send) drive KakaoTalk's UI directly via the Accessibility API and work fully without a server session.
 </Callout>
 
 ## Introduction
@@ -26,6 +26,9 @@ OpenKakao is most useful when you need a narrow local bridge between KakaoTalk a
   </Card>
   <Card icon={<Send />} title="Send carefully" href="/docs/cli/send">
     Keep outbound actions explicit, reviewable, and easy to narrow when automation starts touching real chats.
+  </Card>
+  <Card icon={<Bot />} title="Send and read without logging in" href="/docs/cli/local-send">
+    `local-send`/`ax-read` drive the real KakaoTalk UI directly — no server session, no local DB dependency.
   </Card>
   <Card icon={<ShieldCheck />} title="Know the trust boundary" href="/docs/security/trust-model">
     Understand what is read locally, what is stored, and where privacy and account-safety assumptions change.

--- a/website/content/docs/overview/changelog.mdx
+++ b/website/content/docs/overview/changelog.mdx
@@ -5,9 +5,19 @@ description: Release notes for OpenKakao.
 
 # Changelog
 
-<Callout type="warn" title="Deprecated as of v1.3.3 (2026-06)">
-This project is no longer actively maintained. Recent KakaoTalk macOS builds broke login: `login --save` can't extract a token, and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS. **Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The read-only `local-*` commands still work. v1.3.2's automated passcode flow relied on endpoints that do not exist on macOS and was reverted in v1.3.3.
+<Callout type="warn" title="Server login is broken (2026-06~)">
+Recent KakaoTalk macOS builds broke login: `login --save` can't extract a token, and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS. **Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). v1.3.2's automated passcode flow relied on endpoints that do not exist on macOS and was reverted in v1.3.3. As of v1.4.0, [`local-send`/`ax-read`](/docs/cli/local-send) give a fully login-free path for both sending and reading.
 </Callout>
+
+## v1.4.0
+
+**AX-only `local-send`, new `ax-read`, chat allowlist — un-deprecated.**
+
+- **Project maintenance resumes.** Server login (`login --save`, `login --manual`) is still broken on recent KakaoTalk builds and remains unfixed (#15, #20, #22) — but `local-send` and the new `ax-read` now give a fully login-free path for both sending and reading, so the CLI is useful again without a working server session.
+- **`local-send` rewritten to be entirely AX-based**, dropping its local-DB dependency. Signature changed from `local-send <chat_id> <message>` to `local-send <chat_name> <message>` — the local SQLCipher DB's key-derivation formula no longer matches current KakaoTalk builds, so chat-id lookups through it are no longer reliable. `local-send` now finds the chat by exact display-name match in KakaoTalk's Accessibility (AX) tree and verifies delivery by scraping the opened chat window's own message list.
+- **New `ax-read <chat_name>`**: read the most recently visible messages in a chat via AX scraping — no server contact, no local DB access.
+- **New `safety.allowed_send_chats`**: an exact-match allowlist `local-send` now requires for real sends, since AX-send has no chat-id to cross-check against.
+- Fixed several AX bugs found while building this: wrong `AXTable` picked up when a chat window was already open, main window stuck on the Friends tab, and `AXSelectedRows` set on the wrong element.
 
 ## v1.1.0
 


### PR DESCRIPTION
## Summary
- `local-send` no longer depends on the local SQLCipher DB — its key-derivation formula has drifted from what current KakaoTalk builds use. It now matches chats by exact display name in the AX tree (`local-send <chat_name> <message>`, was `<chat_id>`) and verifies delivery by scraping the opened chat window directly.
- New `ax-read <chat_name>` command reads the most recently visible messages via the same AX mechanism — no server contact, no local DB access.
- New `safety.allowed_send_chats` exact-match allowlist, required (alongside `safety.allow_ax_send`) for any real `local-send`. There's no chat-id left to cross-check against, so this is the only guard against sending to the wrong chat.
- Fixed AX bugs found while building this: wrong `AXTable` picked up when a chat window was already open, main window stuck on the Friends tab, `AXSelectedRows` set on the row instead of the table.
- README (ko/en), CHANGELOG, and the docs site drop the "deprecated" framing — server login is still broken and undocumented as such, but the CLI is fully usable without it now.
- Version bump 1.3.3 → 1.4.0.

## Test plan
- [x] `cargo test` (unit + `tests/cli_test.rs`) passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `local-send`/`ax-read` manually verified end-to-end against the memo/self chat (real send + AX scrape confirmed delivery)
- [x] Allowlist verified to block a non-allowlisted chat name and allow an allowlisted one
- [x] `website` (`pnpm build`) builds cleanly with the new `cli/local-send` docs page

https://claude.ai/code/session_01DCmATCnDVgwRM3RuVzqN5d