### PR TITLE
hotfix: remove personal name from v1.4.0 example (v1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-02
+
+### Fixed
+- Removed a real personal display name accidentally left in a v1.4.0 code comment and docs example (`src/ax_send.rs`, `website/content/docs/cli/local-send.mdx`), replaced with generic placeholder names. Source-only — never compiled into the binary — but should not have been committed.
+
 ## [1.4.0] - 2026-07-02
 
 ### Un-deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "accessibility",
  "accessibility-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -176,10 +176,10 @@ fn open_chat_row(app: &AXUIElement, chat_display_name: &str) -> Result<()> {
     find_descendants_by_role(table, "AXRow", &mut rows);
 
     // Match on the row's first AXStaticText (the chat name) exactly, not a
-    // substring — "정훈" must not accidentally match a "정훈 & 프리" group
-    // chat. If more than one row has the exact same display name, refuse to
-    // guess rather than silently picking one (there is no chat-id to
-    // disambiguate with — see SafetyConfig::allowed_send_chats).
+    // substring — e.g. "Alice" must not accidentally match an "Alice & Bob"
+    // group chat. If more than one row has the exact same display name,
+    // refuse to guess rather than silently picking one (there is no chat-id
+    // to disambiguate with — see SafetyConfig::allowed_send_chats).
     let mut matches = Vec::new();
     for row in &rows {
         let mut texts = Vec::new();

--- a/website/content/docs/cli/local-send.mdx
+++ b/website/content/docs/cli/local-send.mdx
@@ -11,7 +11,7 @@ description: Send and read real messages without a server session, by driving th
 
 Both commands find the target chat by its **exact display name**, the same text shown in KakaoTalk's chat list — not a chat-id. There is no local database to cross-check the target against anymore, so:
 
-- Matching is exact, not substring — a search for `"정훈"` will not accidentally match a `"정훈 & 프리"` group chat.
+- Matching is exact, not substring — a search for `"Alice"` will not accidentally match an `"Alice & Bob"` group chat.
 - If more than one visible chat shares the exact same display name, both commands refuse to guess and return an error.
 - `local-send` additionally requires the chat to be listed in a config allowlist before it will send for real (see [Safety](#safety) below).
 


### PR DESCRIPTION
## Summary
- A real personal display name was accidentally used as an example string in a code comment (`src/ax_send.rs`) and the new `local-send` docs page instead of a generic placeholder. Replaced with "Alice"/"Bob".
- Source-only — never compiled into the shipped binary — but should not have been committed to a public repo.
- Version bump 1.4.0 → 1.4.1.

## Test plan
- [x] Confirmed no remaining matches for the name across `.rs`/`.md`/`.mdx`/`.toml`/`.json`
- [x] `cargo build --release` + `cargo clippy --all-targets -- -D warnings` clean

https://claude.ai/code/session_01DCmATCnDVgwRM3RuVzqN5d