### PR TITLE
chore: cargo fmt compliance, fix release CI gate (v1.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-07-02
+
+### Fixed
+- `cargo fmt` compliance for the v1.4.0/v1.4.1 AX-send additions — the release CI's `cargo fmt --check` gate failed on both tags, so neither published binaries. No functional change.
+
 ## [1.4.1] - 2026-07-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -68,7 +68,10 @@ fn role(el: &AXUIElement) -> String {
 /// Read an element's `AXValue` as a string (works for `AXStaticText` and
 /// `AXTextArea`; other value types just fail the downcast and are skipped).
 fn value_as_string(el: &AXUIElement) -> Option<String> {
-    el.value().ok().and_then(|v| v.downcast::<CFString>()).map(|s| s.to_string())
+    el.value()
+        .ok()
+        .and_then(|v| v.downcast::<CFString>())
+        .map(|s| s.to_string())
 }
 
 /// Read a string attribute by raw name (works for attributes with no typed
@@ -303,7 +306,10 @@ fn read_visible_messages(window: &AXUIElement) -> Vec<AxMessage> {
 /// Scrape the text of every message bubble currently rendered in a chat
 /// window's message list, in on-screen (chronological) order.
 fn read_visible_message_texts(window: &AXUIElement) -> Vec<String> {
-    read_visible_messages(window).into_iter().map(|m| m.text).collect()
+    read_visible_messages(window)
+        .into_iter()
+        .map(|m| m.text)
+        .collect()
 }
 
 /// Find an already-open chat window whose title matches `chat_display_name`

--- a/src/commands/ax_read.rs
+++ b/src/commands/ax_read.rs
@@ -42,7 +42,10 @@ pub fn cmd_ax_read(opts: AxReadOptions) -> Result<()> {
                 None => println!("{}", m.text),
             }
         }
-        println!("\n{} messages (AX scrape, no server contact)", messages.len());
+        println!(
+            "\n{} messages (AX scrape, no server contact)",
+            messages.len()
+        );
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -585,7 +585,12 @@ fn require_ax_send(config: &config::OpenKakaoConfig) -> Result<()> {
 /// exact-match allowlist in config is the only guard against typos or
 /// substring collisions sending to the wrong chat.
 fn require_allowed_send_chat(config: &config::OpenKakaoConfig, chat_name: &str) -> Result<()> {
-    if !config.safety.allowed_send_chats.iter().any(|c| c == chat_name) {
+    if !config
+        .safety
+        .allowed_send_chats
+        .iter()
+        .any(|c| c == chat_name)
+    {
         anyhow::bail!(
             "chat \"{chat_name}\" is not in the local-send allowlist.\n\n\
              local-send matches chats by display-name text scraped from the KakaoTalk UI,\n\


### PR DESCRIPTION
## Summary
- v1.4.0/v1.4.1's release workflow failed at `cargo fmt --check` on the new AX-send code, so neither actually published binaries (confirmed via `gh release list` — no v1.4.0/v1.4.1 release exists).
- Ran `cargo fmt`, no functional change.
- Version bump 1.4.1 → 1.4.2.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo build --release`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass

https://claude.ai/code/session_01DCmATCnDVgwRM3RuVzqN5d