### PR TITLE
hotfix: remove dead code in non-macOS AX stub (v1.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-07-02
+
+### Fixed
+- v1.4.3's macOS-only dependency gating fixed the Linux `verify` job's build step, but its Rust-target-agnostic clippy pass then flagged the non-macOS stub's `find_kakaotalk_pid` as dead code (it existed but was never called). Removed the unused stub function and marked `stub::AxMessage`'s fields `#[allow(dead_code)]`, since that type exists purely to keep the stub's public API shape matching the real macOS implementation and is never actually constructed on non-macOS builds.
+
 ## [1.4.3] - 2026-07-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "accessibility",
  "accessibility-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -467,14 +467,13 @@ mod stub {
     use anyhow::{anyhow, Result};
 
     /// Mirrors `imp::AxMessage`'s shape so callers don't need cfg-gating.
+    /// Never actually constructed here — `read_via_ax` below always errors
+    /// on this platform — so its fields would otherwise trip `dead_code`.
+    #[allow(dead_code)]
     #[derive(Debug, Clone)]
     pub struct AxMessage {
         pub time: Option<String>,
         pub text: String,
-    }
-
-    pub fn find_kakaotalk_pid() -> Result<i32> {
-        Err(anyhow!("AX automation is only supported on macOS"))
     }
 
     pub fn send_via_ax(_chat_display_name: &str, _message: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
- v1.4.3 fixed the Linux `verify` job's build step (macOS-only AX deps), but its `cargo clippy -D warnings` pass then failed on `dead_code` for the non-macOS stub's unused `find_kakaotalk_pid` function.
- Removed the unused function; `stub::AxMessage`'s fields are `#[allow(dead_code)]` since that type only exists to keep the stub's public API shape matching the real macOS implementation and is never actually constructed there.
- Version bump 1.4.3 → 1.4.4.

## Test plan
- [x] `cargo build --release`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` all pass on macOS (compiles the real `imp` path)
- [x] Confirmed via the v1.4.3 CI run's Linux `verify` job log that this was the only remaining failure (build jobs for both macOS targets already succeeded)

https://claude.ai/code/session_01DCmATCnDVgwRM3RuVzqN5d