### PR TITLE
docs: lead with what works, not what's broken

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,14 +22,11 @@
 
 [한국어](README.md) | **English**
 
-> [!IMPORTANT]
-> **Server login is broken (2026-06~)** — Recent KakaoTalk macOS builds broke **most login paths:**
-> - `login --save` — newer builds no longer cache the auth token, so it cannot be extracted. ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15))
-> - `login --manual` — an unseen device gets `status=-100` (device not registered), but the current macOS app has no automated device-registration (passcode) endpoint (it 404s), so login cannot complete. ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22))
->
-> **🚨 Do NOT repeatedly retry login from an unregistered device.** Kakao may block your account's "sub-device login" or restrict the account (this has actually been reported).
->
-> **But the CLI works fully without logging in.** `local-send`/`ax-read` drive the real KakaoTalk UI directly via the macOS Accessibility API — no server session needed for either sending real messages or reading recent chat history (see [Quick Start](#quick-start) below). The local SQLCipher DB path (`local-chats`/`local-read`/`local-search`) is currently unreliable on recent builds — its key-derivation formula has drifted from what current KakaoTalk uses.
+> [!TIP]
+> **Works fully without logging in.** `local-send`/`ax-read` drive the real KakaoTalk UI directly via the macOS Accessibility API — no server session needed for either sending real messages or reading recent chat history. Just KakaoTalk running and already logged in — see [Quick Start](#quick-start) below.
+
+> [!NOTE]
+> Server login (`login --save`/`login --manual`) is broken on most recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **Do NOT repeatedly retry login from an unregistered device** — Kakao may block your account's "sub-device login" or restrict the account (this has actually been reported). The local SQLCipher DB path (`local-chats`/`local-read`/`local-search`) is also currently unreliable on recent builds — use `ax-read` instead.
 
 > [!WARNING]
 > This project is an unofficial CLI and is not affiliated with or endorsed by Kakao Corp. It is built for research, automation, and local workflows around the macOS KakaoTalk app.

--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@
 
 **한국어** | [English](README.en.md)
 
-> [!IMPORTANT]
-> **서버 로그인이 깨져 있습니다 (2026-06~)** — 최근 KakaoTalk macOS 빌드 변경으로 `login --save`/`login --manual` 경로가 대부분 동작하지 않습니다.
-> - `login --save` — 최신 빌드는 인증 토큰을 캐시에 남기지 않아 추출이 불가능합니다. ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15))
-> - `login --manual` — 처음 보는 기기는 `status=-100`(기기 미등록)을 받는데, 현재 macOS 앱에는 자동 기기 등록(passcode) 엔드포인트가 없어(404) 로그인을 완료할 수 없습니다. ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22))
->
-> **🚨 미등록 기기로 로그인을 반복 시도하지 마세요.** 카카오가 계정의 "서브 디바이스 로그인"을 차단하거나 계정을 제재할 수 있습니다(실제 피해 사례가 보고되었습니다).
->
-> **하지만 로그인 없이도 CLI는 완전히 동작합니다.** `local-send`/`ax-read`는 macOS Accessibility API로 카카오톡 UI를 직접 읽고 조작해서, 서버 세션 없이도 실제 메시지 전송과 최근 대화 읽기를 모두 지원합니다 (아래 [Quick Start](#quick-start) 참고). 로컬 SQLCipher DB(`local-chats`/`local-read`/`local-search`)는 최신 카카오톡 빌드에서 키 유도 공식이 어긋나 있어 현재 신뢰할 수 없습니다.
+> [!TIP]
+> **로그인 없이 바로 동작합니다.** `local-send`/`ax-read`는 macOS Accessibility API로 카카오톡 UI를 직접 읽고 조작해서, 서버 세션 없이도 실제 메시지 전송과 최근 대화 읽기를 지원합니다. KakaoTalk 앱이 실행 중이고 로그인만 되어 있으면 됩니다 — 아래 [Quick Start](#quick-start) 참고.
+
+> [!NOTE]
+> 서버 로그인(`login --save`/`login --manual`)은 최근 KakaoTalk macOS 빌드에서 대부분 동작하지 않습니다 ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **미등록 기기로 로그인을 반복 시도하지 마세요** — 카카오가 계정의 "서브 디바이스 로그인"을 차단하거나 계정을 제재할 수 있습니다(실제 피해 사례가 보고되었습니다). 로컬 SQLCipher DB(`local-chats`/`local-read`/`local-search`)도 최신 빌드에서 키 유도 공식이 어긋나 신뢰할 수 없습니다 — 대신 `ax-read`를 쓰세요.
 
 > [!WARNING]
 > 이 프로젝트는 카카오(Kakao Corp.)와 무관한 비공식 CLI입니다. 연구, 자동화, 로컬 워크플로 용도로 만들었고, 카카오의 승인이나 보증을 받지 않았습니다.

--- a/website/content/docs/getting-started/authentication.mdx
+++ b/website/content/docs/getting-started/authentication.mdx
@@ -5,10 +5,10 @@ description: How OpenKakao authenticates, how recovery policy works, and where u
 
 # Authentication
 
-<Callout type="warn" title="Login is broken on recent KakaoTalk builds">
-As of 2026-06 the login flows below are broken on current KakaoTalk macOS builds. `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)); `login --manual` returns `status=-100` (device not registered) and there is no working device-registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
+This page covers server-side authentication. If you just want to send or read messages, you don't need any of it — see [`local-send`/`ax-read`](/docs/cli/local-send), which drive KakaoTalk's UI directly and never authenticate to Kakao's servers.
 
-**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** Neither of the pages below is required for [`local-send`/`ax-read`](/docs/cli/local-send), which never authenticate to Kakao's servers at all.
+<Callout type="warn" title="Login is broken on recent KakaoTalk builds">
+`login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)); `login --manual` returns `status=-100` (device not registered) and there is no working device-registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.**
 </Callout>
 
 OpenKakao derives authentication material from the running KakaoTalk macOS app and stores reusable credentials locally only when you ask it to.

--- a/website/content/docs/getting-started/quickstart.mdx
+++ b/website/content/docs/getting-started/quickstart.mdx
@@ -6,12 +6,6 @@ icon: Rocket
 
 import { KeyRound, ListTree, MessageSquareText, Terminal } from 'lucide-react';
 
-<Callout type="warn" title="Server login is broken (2026-06~)">
-Login no longer works on recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). The "Authenticate once" step below will fail. **Do not repeatedly retry login — it can get your account's sub-device login blocked.**
-
-You don't need login at all to send or read messages: skip straight to [Login-free path](#login-free-path) below. `local-send`/`ax-read` drive the KakaoTalk UI directly via the Accessibility API.
-</Callout>
-
 ## Login-free path
 
 No server session required — just KakaoTalk running and already logged in on this Mac.
@@ -39,9 +33,13 @@ openkakao-cli local-send "chat display name" "Hello from CLI!" --dry-run
 openkakao-cli local-send "chat display name" "Hello from CLI!" -y
 ```
 
-See [local-send / ax-read](/docs/cli/local-send) for the full reference. The rest of this page covers the server-login path, which is currently broken on most KakaoTalk builds.
+See [local-send / ax-read](/docs/cli/local-send) for the full reference.
 
 ## Introduction
+
+<Callout type="warn" title="The path below needs server login, which is currently broken">
+`login --save`/`login --manual` fail on most current KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)), so "Authenticate once" below will fail for most people — the [Login-free path](#login-free-path) above doesn't need any of this. If you do attempt server login, **do not repeatedly retry from an unregistered device — it can get your account's sub-device login blocked.**
+</Callout>
 
 This path is intentionally narrow: install, authenticate, inspect a chat, then stop and evaluate whether the trust model fits your use case.
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -5,10 +5,12 @@ description: Developer docs for bringing KakaoTalk into local workflows on macOS
 
 import { Bot, History, Send, ShieldCheck } from 'lucide-react';
 
-<Callout type="warn" title="Server login is broken on recent KakaoTalk builds (2026-06~)">
-Recent KakaoTalk macOS builds broke the login paths: `login --save` can no longer extract a token ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15)), and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)).
+<Callout title="Works without logging in">
+[`local-send`/`ax-read`](/docs/cli/local-send) drive KakaoTalk's UI directly through the macOS Accessibility API, so sending and reading real messages both work with no server session at all — just KakaoTalk running and already logged in.
+</Callout>
 
-**Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.** You don't need it anyway: [`local-send`/`ax-read`](/docs/cli/local-send) drive KakaoTalk's UI directly via the Accessibility API and work fully without a server session.
+<Callout type="warn" title="Server login is broken on recent KakaoTalk builds">
+`login --save`/`login --manual` fail on current KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)) — not needed for the path above. **Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked.**
 </Callout>
 
 ## Introduction

--- a/website/content/docs/overview/changelog.mdx
+++ b/website/content/docs/overview/changelog.mdx
@@ -5,8 +5,8 @@ description: Release notes for OpenKakao.
 
 # Changelog
 
-<Callout type="warn" title="Server login is broken (2026-06~)">
-Recent KakaoTalk macOS builds broke login: `login --save` can't extract a token, and `login --manual` returns `status=-100` (device not registered) with no working registration endpoint on macOS. **Do not repeatedly retry login from an unregistered device — it can get your account's sub-device login blocked** ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). v1.3.2's automated passcode flow relied on endpoints that do not exist on macOS and was reverted in v1.3.3. As of v1.4.0, [`local-send`/`ax-read`](/docs/cli/local-send) give a fully login-free path for both sending and reading.
+<Callout title="Currently: login-free send/read via local-send / ax-read">
+As of v1.4.0, [`local-send`/`ax-read`](/docs/cli/local-send) give a fully login-free path for both sending and reading real messages. Server login (`login --save`/`login --manual`) is still broken on recent KakaoTalk macOS builds ([#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)) — **do not repeatedly retry it from an unregistered device, that can get your account's sub-device login blocked.**
 </Callout>
 
 ## v1.4.0


### PR DESCRIPTION
## Summary
- README (ko/en) and the docs site (index, quickstart, authentication, changelog) all opened with a "server login is broken" warning, with the working login-free path (`local-send`/`ax-read`) mentioned only as a footnote — giving an overall "everything here is broken" impression even though send/read work fine without login.
- Reordered every affected page so the working path leads (as a plain/TIP callout), and the server-login limitation becomes a secondary NOTE/WARN rather than the dominant framing.
- Also updated the GitHub repo "About" description (was still literally `[DEPRECATED — unmaintained...]`, separate from README content, missed in the earlier un-deprecation pass).
- No functional/code change — docs and repo metadata only.

## Test plan
- [x] `website` (`pnpm build`) builds cleanly
- [x] Manually reviewed each changed page's rendered flow

https://claude.ai/code/session_01DCmATCnDVgwRM3RuVzqN5d