### PR TITLE
hotfix: allow(dead_code) for match_chat_row on non-macOS (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-02
+
+### Fixed
+- v1.5.0's release CI failed: `ChatMatch`/`match_chat_row` (the pure, cross-platform chat-matching function added in v1.5.0) are only called by the macOS-only `imp::open_chat_row`, so on non-macOS builds — where `mod imp` doesn't compile and `mod stub` never needs to match a chat row — they were unused outside tests and flagged as `dead_code` under `-D warnings`. Marked `#[cfg_attr(not(target_os = "macos"), allow(dead_code))]`, the same pattern already used for `stub::AxMessage`.
+
 ## [1.5.0] - 2026-07-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "accessibility",
  "accessibility-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 description = "Rust CLI client for KakaoTalk macOS cached APIs"
 license = "MIT"

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -20,6 +20,11 @@
 //! stub with the same public API stands in on other platforms so the crate
 //! still builds and lints in cross-platform CI.
 
+// Only `imp::open_chat_row` (macOS-only) actually calls these outside of
+// tests, so on other platforms — where `mod imp` doesn't compile and
+// `mod stub` never needs to match a chat row at all — they're otherwise
+// flagged as dead code by the real (non-test) build.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ChatMatch {
     Found(usize),
@@ -27,6 +32,7 @@ pub(crate) enum ChatMatch {
     Ambiguous(usize),
 }
 
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn match_chat_row(row_names: &[Option<String>], target: &str) -> ChatMatch {
     let mut matches = row_names
         .iter()


### PR DESCRIPTION
## Summary
- v1.5.0's release CI failed at the Linux `verify`/`lint` job: `ChatMatch`/`match_chat_row` (the pure cross-platform function from v1.5.0's Task 1) are only called by the macOS-only `imp::open_chat_row`. On non-macOS, `mod imp` doesn't compile and `mod stub` never needs chat-matching at all, so both items are unused outside `#[cfg(test)]` and get flagged `dead_code` under `-D warnings`.
- Fixed with the same `#[cfg_attr(not(target_os = "macos"), allow(dead_code))]` pattern already used for `stub::AxMessage` since v1.4.4.
- This time: **not merging until this PR's own CI checks are green** — `openkakao-cli-ci.yml` runs on `pull_request` and builds/lints/tests on `ubuntu-latest`, which is exactly the job that would have caught this (and the v1.4.0-v1.4.4 issues) before merge if I'd waited for it instead of only checking macOS-local results.

## Test plan
- [x] `cargo build`/`clippy`/`fmt`/`test` pass on macOS
- [ ] **Waiting for this PR's CI checks (`openkakao-cli-ci.yml`, runs on Linux) to go green before merging** — this is the actual verification for this specific bug class

Claude-Session: https://claude.ai/code/session_01DCmATCnDVgwRM3RuVzqN5d