### PR TITLE
release: v1.7.0 (ax-watch — login-free receive detection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-03
+
+### Added
+- **`ax-watch`** — login-free, background receive detection. Polls KakaoTalk's chat list via the macOS Accessibility API and fires hooks/webhooks when a chat's unread count increases. No server contact (no ban risk), never steals focus, never opens a chat (unread state stays untouched). A background-friendly replacement for the LOCO-based `watch`, which needs a server session that recent KakaoTalk builds break.
+  - Filters: `--hook-chat <exact display name>`, `--hook-keyword <text matched against the chat's message preview>`.
+  - `--json` emits one NDJSON event per detected increase; console output otherwise.
+  - Gated by `--allow-watch-side-effects` (same flag as `watch`) when a hook/webhook is configured.
+  - Only polls visible/loaded chat rows — a new message bumps its chat to the top of the list, so incoming activity is caught without scrolling.
+  - `WatchMessageEvent` gained an additive `unread` field and `WatchHookConfig` an additive `chat_names` filter; both are backward-compatible and don't change existing `watch` behavior.
+
+### Fixed
+- `local-send`/`ax-read`/`ax-watch` now give a clear, actionable error when KakaoTalk's main chat-list window can't be found because it's **minimized** or **on a different macOS Space (virtual desktop)** than the one currently active — both cases previously surfaced as a generic "is it open?" message. The Accessibility API only sees windows on the active Space, and a minimized window's `AXMinimized` state was found (via live testing) to sometimes bring KakaoTalk to the foreground if auto-restored — since this tool never steals focus, it now asks you to un-minimize by hand instead. One-time fix if this keeps happening: right-click the KakaoTalk Dock icon → Options → Assign To → All Desktops.
+
 ## [1.6.0] - 2026-07-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "accessibility",
  "accessibility-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 description = "KakaoTalk CLI for macOS — send/read messages without server login via Accessibility automation"
 license = "MIT"

--- a/README.en.md
+++ b/README.en.md
@@ -84,6 +84,10 @@ openkakao-cli local-send "chat display name" "Hello from CLI!" -y         # actu
 
 # 3. Read recent messages — same AX approach, scrapes what's rendered on screen
 openkakao-cli ax-read "chat display name" -n 20
+
+# 4. Detect incoming messages — polls the chat list and fires a hook/webhook
+#    when a chat's unread count rises (no server contact)
+openkakao-cli ax-watch --hook-cmd 'my-script.sh'
 ```
 
 ### Server-login path (mostly broken right now)
@@ -190,6 +194,7 @@ Read-only operations are always available:
 | Command | Description | Server Contact |
 |---------|-------------|----------------|
 | `ax-read <chat_name>` | Scrape recent messages from an open chat window (AX) | None |
+| `ax-watch` | Poll the chat list, fire a hook/webhook when unread count rises (AX, no login) | None |
 | `local-chats` | List chats from local DB (unreliable on current builds) | None |
 | `local-read <id>` | Read messages from local DB (unreliable on current builds) | None |
 | `local-search "keyword"` | Search local DB (unreliable on current builds) | None |
@@ -197,6 +202,9 @@ Read-only operations are always available:
 | `read <id> --rest` | Read messages via REST | REST |
 | `send ... --dry-run` | Preview send without executing | None |
 | `local-send ... --dry-run` | Preview an AX send without executing | None |
+
+> [!NOTE]
+> `local-send`/`ax-read`/`ax-watch` need to find KakaoTalk's **main chat-list window** via the macOS Accessibility API. If that window is **minimized**, or on a different **macOS Space** (virtual desktop) than the one you're currently viewing, it won't be found — restoring it automatically isn't possible without risking a stolen foreground focus, so these commands give a clear error and ask you to restore it by hand instead. If this keeps happening, a one-time fix is: right-click the KakaoTalk Dock icon → Options → Assign To → All Desktops.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ openkakao-cli local-send "채팅방 표시 이름" "Hello from CLI!" -y         
 
 # 3. 최근 메시지 읽기 — 같은 방식(AX)으로 화면에 보이는 메시지를 스크랩
 openkakao-cli ax-read "채팅방 표시 이름" -n 20
+
+# 4. 수신 감지 — 채팅 목록을 폴링해 안읽음이 늘면 hook/webhook 발화 (서버 접촉 없음)
+openkakao-cli ax-watch --hook-cmd 'my-script.sh'
 ```
 
 ### 서버 로그인 기반 (현재 대부분 깨짐)
@@ -190,6 +193,7 @@ allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 
 | 명령 | 설명 | 서버 통신 |
 |------|------|-----------|
 | `ax-read <chat_name>` | 화면에 열린 채팅의 최근 메시지 스크랩 (AX) | 없음 |
+| `ax-watch` | 채팅 목록을 폴링해 안읽음 증가 시 hook/webhook 발화 (AX, 로그인 불필요) | 없음 |
 | `local-chats` | 로컬 DB 채팅 목록 (최신 빌드에서 신뢰 불가) | 없음 |
 | `local-read <id>` | 로컬 DB 메시지 읽기 (최신 빌드에서 신뢰 불가) | 없음 |
 | `local-search "keyword"` | 로컬 DB 검색 (최신 빌드에서 신뢰 불가) | 없음 |
@@ -197,6 +201,9 @@ allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 
 | `read <id> --rest` | REST API 메시지 읽기 | REST |
 | `send ... --dry-run` | 전송 미리보기 | 없음 |
 | `local-send ... --dry-run` | AX 전송 미리보기 | 없음 |
+
+> [!NOTE]
+> `local-send`/`ax-read`/`ax-watch`는 macOS Accessibility API로 카카오톡의 **메인 채팅 목록 창**을 찾아야 동작합니다. 이 창이 **최소화**돼 있거나 현재 보고 있는 것과 **다른 macOS Space(가상 데스크탑)**에 있으면 찾지 못합니다(포커스를 뺏지 않고는 자동 복구가 불가능해서, 명확한 에러만 내고 직접 복원을 요청합니다). 계속 겪는다면 Dock의 카카오톡 아이콘 우클릭 → Options → Assign To → All Desktops로 한 번만 설정해두세요.
 
 ## 요구 사항
 

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -817,9 +817,6 @@ mod stub {
         pub timestamp: String,
     }
 
-    // Unused until Task 4 wires the consuming command; drop this once that
-    // lands.
-    #[allow(dead_code)]
     pub fn scrape_chat_list() -> Result<Vec<ChatListRow>> {
         Err(anyhow!(
             "ax-watch (AX automation) is only supported on macOS"
@@ -827,8 +824,5 @@ mod stub {
     }
 }
 
-// scrape_chat_list/ChatListRow are unused until Task 4 wires the consuming
-// command; drop this allow once that lands.
 #[cfg(not(target_os = "macos"))]
-#[allow(unused_imports)]
 pub use stub::{read_via_ax, scrape_chat_list, send_via_ax, ChatListRow};

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -679,6 +679,82 @@ mod imp {
         }
     }
 
+    /// One chat-list row scraped from the main window, read-only (never opens
+    /// the chat, so its unread state is untouched).
+    // Fields are unused until Task 4 wires the consuming command; drop this
+    // once that lands.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone)]
+    pub struct ChatListRow {
+        pub name: String,
+        pub unread: i32,
+        pub preview: String,
+        pub timestamp: String,
+    }
+
+    /// Scrape every visible/loaded chat-list row from KakaoTalk's main window.
+    /// Uses the same single-snapshot chat-list traversal as `open_chat_row`
+    /// (main window → chatrooms tab → AXTable → AXRow), but only reads each
+    /// row instead of selecting it — so nothing is opened and no unread state
+    /// changes. Rows with no readable name are skipped.
+    // Unused until Task 4 wires the consuming command; drop this once that
+    // lands.
+    #[allow(dead_code)]
+    pub fn scrape_chat_list() -> Result<Vec<ChatListRow>> {
+        let pid = find_kakaotalk_pid()?;
+        ensure_ax_permission()?;
+        let app = AXUIElement::application(pid);
+        let main_window = find_main_window(&app)?;
+        let snap = ensure_chatrooms_tab(&main_window);
+        let table = snap
+            .find_first("AXTable")
+            .ok_or_else(|| anyhow!("could not find chat list table in KakaoTalk's AX tree"))?;
+
+        let mut rows = Vec::new();
+        table.find_all("AXRow", &mut rows);
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let mut static_texts = Vec::new();
+            row.find_all("AXStaticText", &mut static_texts);
+            // The first static text is the chat name (same convention as
+            // open_chat_row). Skip rows we can't name.
+            let Some(name) = static_texts.first().and_then(|t| t.value.clone()) else {
+                continue;
+            };
+            // Among the remaining static texts, the unread badge is the one
+            // whose whole value parses as an integer (e.g. "5"); a
+            // non-numeric one (e.g. "어제", "오후 3:14") is the timestamp.
+            let mut unread = 0;
+            let mut timestamp = String::new();
+            for t in static_texts.iter().skip(1) {
+                let Some(v) = t.value.as_deref() else {
+                    continue;
+                };
+                if let Ok(n) = v.trim().parse::<i32>() {
+                    if unread == 0 {
+                        unread = n;
+                    }
+                } else if timestamp.is_empty() {
+                    timestamp = v.to_string();
+                }
+            }
+            // The last-message preview is the row's AXTextArea value.
+            let preview = row
+                .find_first("AXTextArea")
+                .and_then(|t| t.value.clone())
+                .unwrap_or_default();
+
+            out.push(ChatListRow {
+                name,
+                unread,
+                preview,
+                timestamp,
+            });
+        }
+        Ok(out)
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -703,8 +779,11 @@ mod imp {
     }
 } // mod imp
 
+// scrape_chat_list/ChatListRow are unused until Task 4 wires the consuming
+// command; drop this allow once that lands.
 #[cfg(target_os = "macos")]
-pub use imp::{read_via_ax, send_via_ax};
+#[allow(unused_imports)]
+pub use imp::{read_via_ax, scrape_chat_list, send_via_ax, ChatListRow};
 
 #[cfg(not(target_os = "macos"))]
 mod stub {
@@ -731,7 +810,30 @@ mod stub {
             "ax-read (AX automation) is only supported on macOS"
         ))
     }
+
+    /// Mirrors `imp::ChatListRow`. Never constructed off macOS (the fn below
+    /// always errors), so its fields would otherwise trip `dead_code`.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone)]
+    pub struct ChatListRow {
+        pub name: String,
+        pub unread: i32,
+        pub preview: String,
+        pub timestamp: String,
+    }
+
+    // Unused until Task 4 wires the consuming command; drop this once that
+    // lands.
+    #[allow(dead_code)]
+    pub fn scrape_chat_list() -> Result<Vec<ChatListRow>> {
+        Err(anyhow!(
+            "ax-watch (AX automation) is only supported on macOS"
+        ))
+    }
 }
 
+// scrape_chat_list/ChatListRow are unused until Task 4 wires the consuming
+// command; drop this allow once that lands.
 #[cfg(not(target_os = "macos"))]
-pub use stub::{read_via_ax, send_via_ax};
+#[allow(unused_imports)]
+pub use stub::{read_via_ax, scrape_chat_list, send_via_ax, ChatListRow};

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -113,6 +113,7 @@ mod imp {
     use anyhow::{anyhow, Context, Result};
     use core_foundation::array::{CFArray, CFArrayRef};
     use core_foundation::base::{CFType, TCFType};
+    use core_foundation::boolean::CFBoolean;
     use core_foundation::string::CFString;
     use core_graphics::event::CGEvent;
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
@@ -183,13 +184,44 @@ mod imp {
         let windows = app
             .windows()
             .map_err(|e| anyhow!("AXWindows read failed: {e:?}"))?;
-        windows
+        let window = windows
             .iter()
             .find(|w| attr_as_string(w, "AXIdentifier").as_deref() == Some("Main Window"))
             .map(|w| w.clone())
             .ok_or_else(|| {
-                anyhow!("could not find KakaoTalk's main chat-list window — is it open?")
-            })
+                anyhow!(
+                    "could not find KakaoTalk's main chat-list window. Make sure it's open, not \
+                     minimized, and on the Space (virtual desktop) you're currently viewing — the \
+                     Accessibility API only sees windows that are visible on the active Space, and \
+                     restoring a minimized/off-Space window automatically risks stealing your \
+                     foreground focus, which this tool never does. One-time fix if this keeps \
+                     happening: right-click the KakaoTalk Dock icon → Options → \
+                     Assign To → All Desktops."
+                )
+            })?;
+
+        // Note: a minimized window still shows up here (unlike one on another
+        // Space, which disappears from `windows()` entirely), but restoring
+        // it via AXMinimized=false was observed to sometimes bring KakaoTalk
+        // to the foreground — which this tool must never do — so we
+        // deliberately do NOT auto-restore. The caller gets the same "not
+        // found" error and a manual fix, same as the off-Space case.
+        let minimized_attr: AXAttribute<CFType> = AXAttribute::new(&CFString::new("AXMinimized"));
+        let is_minimized = window
+            .attribute(&minimized_attr)
+            .ok()
+            .and_then(|v| v.downcast::<CFBoolean>())
+            .map(bool::from)
+            == Some(true);
+        if is_minimized {
+            return Err(anyhow!(
+                "KakaoTalk's main chat-list window is minimized. Restoring it automatically risks \
+                 stealing your foreground focus, which this tool never does — please un-minimize \
+                 it yourself (click its Dock icon) and retry."
+            ));
+        }
+
+        Ok(window)
     }
 
     /// A single recursive snapshot of an AX subtree, capturing each node's

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -681,14 +681,15 @@ mod imp {
 
     /// One chat-list row scraped from the main window, read-only (never opens
     /// the chat, so its unread state is untouched).
-    // Fields are unused until Task 4 wires the consuming command; drop this
-    // once that lands.
-    #[allow(dead_code)]
     #[derive(Debug, Clone)]
     pub struct ChatListRow {
         pub name: String,
         pub unread: i32,
         pub preview: String,
+        // Scraped for completeness but not currently consumed by any caller
+        // (ax-watch's event doesn't need the row's own last-message
+        // timestamp); keep it available for future use.
+        #[allow(dead_code)]
         pub timestamp: String,
     }
 
@@ -697,9 +698,6 @@ mod imp {
     /// (main window → chatrooms tab → AXTable → AXRow), but only reads each
     /// row instead of selecting it — so nothing is opened and no unread state
     /// changes. Rows with no readable name are skipped.
-    // Unused until Task 4 wires the consuming command; drop this once that
-    // lands.
-    #[allow(dead_code)]
     pub fn scrape_chat_list() -> Result<Vec<ChatListRow>> {
         let pid = find_kakaotalk_pid()?;
         ensure_ax_permission()?;
@@ -779,10 +777,7 @@ mod imp {
     }
 } // mod imp
 
-// scrape_chat_list/ChatListRow are unused until Task 4 wires the consuming
-// command; drop this allow once that lands.
 #[cfg(target_os = "macos")]
-#[allow(unused_imports)]
 pub use imp::{read_via_ax, scrape_chat_list, send_via_ax, ChatListRow};
 
 #[cfg(not(target_os = "macos"))]

--- a/src/commands/ax_watch.rs
+++ b/src/commands/ax_watch.rs
@@ -1,0 +1,54 @@
+//! `ax-watch` — login-free receive detection. Polls KakaoTalk's chat list via
+//! the macOS Accessibility API and fires the existing hook/webhook machinery
+//! when a chat's unread count increases. No server contact (no ban risk),
+//! background (never steals focus), non-intrusive (never opens a chat, so
+//! unread state is untouched). Replaces the LOCO-based `watch`, which needs a
+//! server session that recent KakaoTalk builds break.
+
+/// Decide whether a chat-list row should fire an event this poll.
+///
+/// - The first poll (`first == true`) only records a baseline and never fires,
+///   so pre-existing unread messages don't flood on startup.
+/// - Afterwards, fire when the unread count rose above the previous value. A
+///   row not seen before (`prev == None`) counts as previously 0, so a chat
+///   that appears with unread (e.g. a new message bumped a formerly off-screen
+///   chat to the top) still fires.
+#[allow(dead_code)] // Called by Task 4's poll loop
+pub fn should_emit(prev: Option<i32>, cur: i32, first: bool) -> bool {
+    !first && cur > prev.unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_poll_never_emits() {
+        assert!(!should_emit(None, 5, true));
+        assert!(!should_emit(Some(0), 5, true));
+    }
+
+    #[test]
+    fn emits_when_unread_increases() {
+        assert!(should_emit(Some(0), 3, false));
+        assert!(should_emit(Some(2), 5, false));
+    }
+
+    #[test]
+    fn no_emit_when_unread_same_or_decreases() {
+        assert!(!should_emit(Some(3), 3, false));
+        assert!(!should_emit(Some(5), 2, false));
+    }
+
+    #[test]
+    fn newly_seen_chat_with_unread_emits() {
+        // prev None (first time this chat appears in the list) on a non-first
+        // poll: a real incoming message that bumped the chat into view.
+        assert!(should_emit(None, 1, false));
+    }
+
+    #[test]
+    fn newly_seen_chat_without_unread_does_not_emit() {
+        assert!(!should_emit(None, 0, false));
+    }
+}

--- a/src/commands/ax_watch.rs
+++ b/src/commands/ax_watch.rs
@@ -5,18 +5,6 @@
 //! unread state is untouched). Replaces the LOCO-based `watch`, which needs a
 //! server session that recent KakaoTalk builds break.
 
-/// Decide whether a chat-list row should fire an event this poll.
-///
-/// - The first poll (`first == true`) only records a baseline and never fires,
-///   so pre-existing unread messages don't flood on startup.
-/// - Afterwards, fire when the unread count rose above the previous value. A
-///   row not seen before (`prev == None`) counts as previously 0, so a chat
-///   that appears with unread (e.g. a new message bumped a formerly off-screen
-///   chat to the top) still fires.
-pub fn should_emit(prev: Option<i32>, cur: i32, first: bool) -> bool {
-    !first && cur > prev.unwrap_or(0)
-}
-
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -28,6 +16,18 @@ use crate::commands::watch::{
     watch_hook_matches, WatchHookConfig, WatchMessageEvent, WebhookFormat,
 };
 use crate::util::require_permission;
+
+/// Decide whether a chat-list row should fire an event this poll.
+///
+/// - The first poll (`first == true`) only records a baseline and never fires,
+///   so pre-existing unread messages don't flood on startup.
+/// - Afterwards, fire when the unread count rose above the previous value. A
+///   row not seen before (`prev == None`) counts as previously 0, so a chat
+///   that appears with unread (e.g. a new message bumped a formerly off-screen
+///   chat to the top) still fires.
+pub fn should_emit(prev: Option<i32>, cur: i32, first: bool) -> bool {
+    !first && cur > prev.unwrap_or(0)
+}
 
 pub struct AxWatchOptions {
     pub interval_secs: u64,
@@ -49,10 +49,10 @@ pub struct AxWatchOptions {
     pub allow_side_effects: bool,
 }
 
-/// Build the current-time ISO-8601 string, matching the format the LOCO watch
-/// uses for `received_at`.
+/// Build the current-time ISO-8601 string, matching the LOCO watch's
+/// `received_at` format (UTC, RFC 3339) so both event sources agree.
 fn now_iso() -> String {
-    chrono::Local::now().to_rfc3339()
+    chrono::Utc::now().to_rfc3339()
 }
 
 fn build_event(row: &ax_send::ChatListRow) -> WatchMessageEvent {

--- a/src/commands/ax_watch.rs
+++ b/src/commands/ax_watch.rs
@@ -13,9 +13,165 @@
 ///   row not seen before (`prev == None`) counts as previously 0, so a chat
 ///   that appears with unread (e.g. a new message bumped a formerly off-screen
 ///   chat to the top) still fires.
-#[allow(dead_code)] // Called by Task 4's poll loop
 pub fn should_emit(prev: Option<i32>, cur: i32, first: bool) -> bool {
     !first && cur > prev.unwrap_or(0)
+}
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::ax_send;
+use crate::commands::watch::{
+    parse_webhook_header, run_watch_command_hook_async, run_watch_webhook, validate_webhook_url,
+    watch_hook_matches, WatchHookConfig, WatchMessageEvent, WebhookFormat,
+};
+use crate::util::require_permission;
+
+pub struct AxWatchOptions {
+    pub interval_secs: u64,
+    pub hook_cmd: Option<String>,
+    pub webhook_url: Option<String>,
+    pub webhook_headers: Vec<String>,
+    pub webhook_signing_secret: Option<String>,
+    pub webhook_format: WebhookFormat,
+    pub hook_chats: Vec<String>,
+    pub hook_keywords: Vec<String>,
+    pub fail_fast: bool,
+    pub allow_insecure_webhooks: bool,
+    pub min_hook_interval_secs: u64,
+    pub min_webhook_interval_secs: u64,
+    pub hook_timeout_secs: u64,
+    pub webhook_timeout_secs: u64,
+    pub json: bool,
+    pub unattended: bool,
+    pub allow_side_effects: bool,
+}
+
+/// Build the current-time ISO-8601 string, matching the format the LOCO watch
+/// uses for `received_at`.
+fn now_iso() -> String {
+    chrono::Local::now().to_rfc3339()
+}
+
+fn build_event(row: &ax_send::ChatListRow) -> WatchMessageEvent {
+    WatchMessageEvent {
+        event_type: "ax_unread",
+        received_at: now_iso(),
+        method: "ax".to_string(),
+        chat_id: 0,
+        chat_name: row.name.clone(),
+        log_id: 0,
+        author_id: 0,
+        author_nickname: String::new(),
+        message_type: 1,
+        message: row.preview.clone(),
+        attachment: String::new(),
+        unread: row.unread,
+    }
+}
+
+/// Poll KakaoTalk's chat list and fire hooks/webhooks on unread increases.
+/// Runs until interrupted (Ctrl-C). Never opens a chat, never steals focus.
+pub fn cmd_ax_watch(options: AxWatchOptions) -> Result<()> {
+    if options.hook_cmd.is_some() || options.webhook_url.is_some() {
+        require_permission(
+            options.unattended && options.allow_side_effects,
+            "ax-watch side effects (hooks or webhooks)",
+            "Re-run with --unattended --allow-watch-side-effects, or set both in ~/.config/openkakao/config.toml.",
+        )?;
+    }
+
+    if let Some(url) = &options.webhook_url {
+        validate_webhook_url(url, options.allow_insecure_webhooks)?;
+    }
+    let webhook_headers = options
+        .webhook_headers
+        .iter()
+        .map(|h| parse_webhook_header(h))
+        .collect::<Result<Vec<_>>>()?;
+
+    let hook_config = WatchHookConfig {
+        command: options.hook_cmd.clone(),
+        webhook_url: options.webhook_url.clone(),
+        webhook_headers,
+        webhook_signing_secret: options.webhook_signing_secret.clone(),
+        webhook_format: options.webhook_format,
+        chat_ids: vec![],
+        chat_names: options.hook_chats.clone(),
+        keywords: options.hook_keywords.clone(),
+        message_types: vec![],
+        fail_fast: options.fail_fast,
+        min_hook_interval_secs: options.min_hook_interval_secs,
+        min_webhook_interval_secs: options.min_webhook_interval_secs,
+        hook_timeout_secs: options.hook_timeout_secs,
+        webhook_timeout_secs: options.webhook_timeout_secs,
+    };
+    let has_sinks = hook_config.command.is_some() || hook_config.webhook_url.is_some();
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let mut baseline: HashMap<String, i32> = HashMap::new();
+        let mut first = true;
+        eprintln!(
+            "[ax-watch] polling KakaoTalk chat list every {}s (Ctrl-C to stop)",
+            options.interval_secs
+        );
+        loop {
+            match ax_send::scrape_chat_list() {
+                Ok(rows) => {
+                    for row in &rows {
+                        let prev = baseline.get(&row.name).copied();
+                        if should_emit(prev, row.unread, first) {
+                            let event = build_event(row);
+                            if options.json {
+                                println!("{}", event.as_json());
+                            } else {
+                                eprintln!(
+                                    "[ax-watch] {} (+{} unread): {}",
+                                    event.chat_name, event.unread, event.message
+                                );
+                            }
+                            if has_sinks && watch_hook_matches(&hook_config, &event) {
+                                if hook_config.command.is_some() {
+                                    if let Err(e) =
+                                        run_watch_command_hook_async(&hook_config, &event).await
+                                    {
+                                        eprintln!("[ax-watch] hook failed: {e}");
+                                        if hook_config.fail_fast {
+                                            return Err(e);
+                                        }
+                                    }
+                                }
+                                if hook_config.webhook_url.is_some() {
+                                    let cfg = hook_config.clone();
+                                    let ev = event.clone();
+                                    if let Err(e) = tokio::task::spawn_blocking(move || {
+                                        run_watch_webhook(&cfg, &ev)
+                                    })
+                                    .await
+                                    .unwrap_or_else(|e| Err(anyhow::anyhow!(e)))
+                                    {
+                                        eprintln!("[ax-watch] webhook failed: {e}");
+                                        if hook_config.fail_fast {
+                                            return Err(e);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        baseline.insert(row.name.clone(), row.unread);
+                    }
+                    first = false;
+                }
+                Err(e) => {
+                    eprintln!("[ax-watch] scrape failed (retrying next poll): {e}");
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(options.interval_secs)).await;
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod analytics;
 pub mod auth;
 pub mod ax_read;
+pub mod ax_watch;
 pub mod chats;
 pub mod doctor;
 pub mod download;

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -50,6 +50,7 @@ pub struct WatchHookConfig {
     pub webhook_signing_secret: Option<String>,
     pub webhook_format: WebhookFormat,
     pub chat_ids: Vec<i64>,
+    pub chat_names: Vec<String>,
     pub keywords: Vec<String>,
     pub message_types: Vec<i32>,
     pub fail_fast: bool,
@@ -103,6 +104,7 @@ pub struct WatchMessageEvent {
     pub message_type: i32,
     pub message: String,
     pub attachment: String,
+    pub unread: i32,
 }
 
 impl WatchMessageEvent {
@@ -119,12 +121,17 @@ impl WatchMessageEvent {
             "message_type": self.message_type,
             "message": self.message,
             "attachment": self.attachment,
+            "unread": self.unread,
         })
     }
 }
 
 pub fn watch_hook_matches(config: &WatchHookConfig, event: &WatchMessageEvent) -> bool {
     if !config.chat_ids.is_empty() && !config.chat_ids.contains(&event.chat_id) {
+        return false;
+    }
+
+    if !config.chat_names.is_empty() && !config.chat_names.contains(&event.chat_name) {
         return false;
     }
 
@@ -476,6 +483,7 @@ async fn handle_msg_packet(
         message_type: msg_type,
         message: content.clone(),
         attachment: attachment.clone(),
+        unread: 0,
     };
 
     if ctx.options.json {
@@ -719,6 +727,7 @@ async fn handle_syncdlmsg_packet(
         message_type: 0,
         message: String::new(),
         attachment: String::new(),
+        unread: 0,
     };
 
     if ctx.options.json {
@@ -963,6 +972,7 @@ pub fn cmd_watch(options: WatchOptions) -> Result<()> {
             webhook_signing_secret: options.webhook_signing_secret.clone(),
             webhook_format: options.webhook_format.clone(),
             chat_ids: options.hook_chat_ids.clone(),
+            chat_names: vec![],
             keywords: options.hook_keywords.clone(),
             message_types: options.hook_types.clone(),
             fail_fast: options.hook_fail_fast,
@@ -1257,4 +1267,64 @@ pub fn cmd_watch(options: WatchOptions) -> Result<()> {
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_test_hook_config() -> WatchHookConfig {
+        WatchHookConfig {
+            command: None,
+            webhook_url: None,
+            webhook_headers: vec![],
+            webhook_signing_secret: None,
+            webhook_format: WebhookFormat::Raw,
+            chat_ids: vec![],
+            chat_names: vec![],
+            keywords: vec![],
+            message_types: vec![],
+            fail_fast: false,
+            min_hook_interval_secs: 0,
+            min_webhook_interval_secs: 0,
+            hook_timeout_secs: 10,
+            webhook_timeout_secs: 10,
+        }
+    }
+
+    fn default_test_event() -> WatchMessageEvent {
+        WatchMessageEvent {
+            event_type: "test",
+            received_at: String::new(),
+            method: "ax".to_string(),
+            chat_id: 0,
+            chat_name: String::new(),
+            log_id: 0,
+            author_id: 0,
+            author_nickname: String::new(),
+            message_type: 1,
+            message: String::new(),
+            attachment: String::new(),
+            unread: 0,
+        }
+    }
+
+    #[test]
+    fn chat_names_filter_matches_exact_name() {
+        let mut config = default_test_hook_config();
+        config.chat_names = vec!["정훈".to_string()];
+        let mut event = default_test_event();
+        event.chat_name = "정훈".to_string();
+        assert!(watch_hook_matches(&config, &event));
+        event.chat_name = "누군가".to_string();
+        assert!(!watch_hook_matches(&config, &event));
+    }
+
+    #[test]
+    fn empty_chat_names_filter_passes_everything() {
+        let config = default_test_hook_config(); // chat_names empty
+        let mut event = default_test_event();
+        event.chat_name = "아무개".to_string();
+        assert!(watch_hook_matches(&config, &event));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,6 +542,28 @@ enum Commands {
         #[arg(short = 'n', long, default_value_t = 20)]
         count: usize,
     },
+    /// Watch for incoming KakaoTalk messages via AX (no server contact,
+    /// background) and fire hooks/webhooks on unread-count increases
+    AxWatch {
+        #[arg(long, default_value_t = 3)]
+        interval: u64,
+        #[arg(long)]
+        hook_cmd: Option<String>,
+        #[arg(long)]
+        webhook_url: Option<String>,
+        #[arg(long = "webhook-header")]
+        webhook_header: Vec<String>,
+        #[arg(long)]
+        webhook_signing_secret: Option<String>,
+        #[arg(long, default_value = "raw")]
+        webhook_format: String,
+        #[arg(long = "hook-chat")]
+        hook_chat: Vec<String>,
+        #[arg(long = "hook-keyword")]
+        hook_keyword: Vec<String>,
+        #[arg(long)]
+        hook_fail_fast: bool,
+    },
     /// Run diagnostic checks on KakaoTalk installation and connectivity
     Doctor {
         /// Also test LOCO booking connectivity (makes network request)
@@ -1259,6 +1281,35 @@ fn main() -> Result<()> {
                 json,
             })?
         }
+        Commands::AxWatch {
+            interval,
+            hook_cmd,
+            webhook_url,
+            webhook_header,
+            webhook_signing_secret,
+            webhook_format,
+            hook_chat,
+            hook_keyword,
+            hook_fail_fast,
+        } => commands::ax_watch::cmd_ax_watch(commands::ax_watch::AxWatchOptions {
+            interval_secs: interval,
+            hook_cmd,
+            webhook_url,
+            webhook_headers: webhook_header,
+            webhook_signing_secret,
+            webhook_format: commands::watch::WebhookFormat::from_str_opt(Some(&webhook_format))?,
+            hook_chats: hook_chat,
+            hook_keywords: hook_keyword,
+            fail_fast: hook_fail_fast,
+            allow_insecure_webhooks: config.safety.allow_insecure_webhooks,
+            min_hook_interval_secs,
+            min_webhook_interval_secs,
+            hook_timeout_secs,
+            webhook_timeout_secs,
+            json,
+            unattended,
+            allow_side_effects: allow_watch_side_effects,
+        })?,
         Commands::WatchCache { interval } => commands::auth::cmd_watch_cache(interval)?,
         Commands::Doctor { loco } => commands::doctor::cmd_doctor(json, loco, &config)?,
     }
@@ -2342,6 +2393,34 @@ mod tests {
                 assert!(!dry_run);
             }
             other => panic!("expected local-send, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ax_watch_command_parses() {
+        let cli = Cli::try_parse_from([
+            "openkakao-cli",
+            "ax-watch",
+            "--interval",
+            "5",
+            "--hook-keyword",
+            "긴급",
+            "--hook-chat",
+            "정훈",
+        ])
+        .expect("ax-watch should parse");
+        match cli.command {
+            Commands::AxWatch {
+                interval,
+                hook_keyword,
+                hook_chat,
+                ..
+            } => {
+                assert_eq!(interval, 5);
+                assert_eq!(hook_keyword, vec!["긴급".to_string()]);
+                assert_eq!(hook_chat, vec!["정훈".to_string()]);
+            }
+            other => panic!("expected ax-watch, got {other:?}"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1367,6 +1367,7 @@ mod tests {
             webhook_signing_secret: None,
             webhook_format: WebhookFormat::Raw,
             chat_ids: vec![42],
+            chat_names: vec![],
             keywords: vec!["urgent".to_string()],
             message_types: vec![1],
             fail_fast: false,
@@ -1387,6 +1388,7 @@ mod tests {
             message_type: 1,
             message: "urgent: ping me".to_string(),
             attachment: String::new(),
+            unread: 0,
         };
 
         assert!(watch_hook_matches(&config, &event));


### PR DESCRIPTION
## Summary
- New `ax-watch`: polls the chat list via AX and fires hooks/webhooks when a chat's unread count increases. Login-free, background (never steals focus), no ban risk, non-intrusive (never opens a chat).
- Reuses the existing `watch` hook/webhook infra (`WatchMessageEvent.unread` + `WatchHookConfig.chat_names` added, backward-compatible — existing LOCO `watch` behavior unchanged).
- Fixes `local-send`/`ax-read`/`ax-watch`'s error message when KakaoTalk's main window is minimized or on a different macOS Space — found via live testing that auto-restoring risked stealing focus, so it now errors clearly instead.
- See `docs/superpowers/specs/2026-07-03-ax-watch-design.md` (local only, gitignored) for the design.

## Test plan
- [x] `cargo build`/`clippy -D warnings`/`fmt --check`/`test` all pass (172 tests incl. `should_emit`, `chat_names` filter, `ax_watch_command_parses`)
- [x] Manual QA on real hardware: real incoming message → event captured within ~2 polls with correct chat name/unread/preview; first poll never floods; focus never stolen (verified with a non-KakaoTalk app frontmost throughout); minimized/off-Space window now gives a clear actionable error with no focus steal
- [x] Subagent-driven development: 4 tasks, each with implementer + task review (spec + quality), plus a final whole-branch review — all clean

Claude-Session: https://claude.ai/code/session_018aWcCtNEWNvdEewLQz8Fy3