### PR TITLE
local-send fast path (already-open chat) + scoped delivery verify

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,38 @@
+# Roadmap
+
+## North star: local DB tailing (replaces AX polling for receive detection)
+
+`ax-watch` today polls the KakaoTalk chat list via the macOS Accessibility API
+and infers "a new message arrived" from list-level signals (unread count,
+message preview). That is a lossy proxy with known limits: it needs the main
+window open/visible on the active Space, only sees loaded chat rows, and can't
+cleanly tell your own sends from incoming messages.
+
+The complete long-term answer is to stop inferring and read the actual message
+stream from KakaoTalk's local SQLCipher DB, which stores every message with a
+monotonic `log_id`:
+
+- A watcher tails `log_id > last_seen` and emits exact message events
+  (author, text, timestamp, chat_id) — no unread/preview heuristics.
+- Works for **all** chats regardless of window state (closed, minimized, on
+  another Space) — the window-visibility requirement disappears entirely.
+- Distinguishes self vs. incoming perfectly; no false positives.
+- Read-only and local: no server contact, no ban risk, no focus stealing.
+
+When this lands, `ax-watch` becomes a fallback rather than the primary path.
+
+**Blocker:** the DB key-derivation formula changed in recent KakaoTalk macOS
+builds (observed on 26.5.0 — the derived filename/key no longer matches
+on-disk), so decryption currently fails even though userId and device UUID are
+recovered. Reaching this north star requires reverse-engineering the current
+key derivation, and it may need redoing on future KakaoTalk builds.
+
+## If the DB stays sealed: message-bubble diffing (AX, Tier 2)
+
+The correct AX-only way to also catch messages in a chat you keep open (where
+the unread count stays 0) is to track the actual message **bubbles** in each
+open window and emit on genuinely new bubbles — distinguishing your own sends
+by bubble alignment/author. This is deliberately *not* the preview-text-change
+heuristic (which fires on your own sends and any room activity). It only works
+for open windows, so it complements list-level unread for closed chats. Build
+this only when real usage hits the open-room gap — until then, YAGNI.

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -121,6 +121,11 @@ mod imp {
     const KAKAOTALK_BUNDLE_ID: &str = "com.kakao.KakaoTalkMac";
     const RETURN_KEYCODE: u16 = 36;
     const OPEN_CHAT_TIMEOUT: Duration = Duration::from_secs(5);
+    // Scoped delivery verification: a single already-open window's bubbles show
+    // the sent text near-instantly, so this can be short (unlike the old
+    // app-wide scan). Normally succeeds on the first poll.
+    const VERIFY_TIMEOUT: Duration = Duration::from_secs(3);
+    const VERIFY_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
     /// Find the running KakaoTalk process id via `pgrep -x`.
     ///
@@ -677,7 +682,29 @@ mod imp {
         }
         press_return(pid)?;
 
-        Ok(())
+        // Scoped verify: poll only the target chat window's own message bubbles
+        // for the sent text — cheap (one window), unlike the old app-wide scan
+        // that could block for tens of seconds. Keeps the fast path fast while
+        // still confirming delivery instead of assuming it.
+        let deadline = Instant::now() + VERIFY_TIMEOUT;
+        loop {
+            if let Some(window) = find_chat_window(&app, chat_display_name) {
+                if read_visible_messages(&window)
+                    .iter()
+                    .any(|m| m.text == message)
+                {
+                    return Ok(());
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "sent the message but could not confirm it appeared in the '{chat_display_name}' \
+                     chat window within {}s — check KakaoTalk before retrying to avoid duplicates",
+                    VERIFY_TIMEOUT.as_secs()
+                ));
+            }
+            sleep(VERIFY_POLL_INTERVAL);
+        }
     }
 
     /// One chat-list row scraped from the main window, read-only (never opens
@@ -761,6 +788,11 @@ mod imp {
         #[test]
         fn open_chat_timeout_is_bounded() {
             assert!(OPEN_CHAT_TIMEOUT.as_secs() > 0);
+        }
+
+        #[test]
+        fn verify_poll_interval_is_smaller_than_timeout() {
+            assert!(VERIFY_POLL_INTERVAL < VERIFY_TIMEOUT);
         }
 
         #[test]

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -121,8 +121,6 @@ mod imp {
     const KAKAOTALK_BUNDLE_ID: &str = "com.kakao.KakaoTalkMac";
     const RETURN_KEYCODE: u16 = 36;
     const OPEN_CHAT_TIMEOUT: Duration = Duration::from_secs(5);
-    const VERIFY_TIMEOUT: Duration = Duration::from_secs(10);
-    const VERIFY_POLL_INTERVAL: Duration = Duration::from_millis(400);
 
     /// Find the running KakaoTalk process id via `pgrep -x`.
     ///
@@ -584,15 +582,6 @@ mod imp {
         None
     }
 
-    /// Scrape the text of every message bubble currently rendered in a chat
-    /// window's message list, in on-screen (chronological) order.
-    fn read_visible_message_texts(window: &AXUIElement) -> Vec<String> {
-        read_visible_messages(window)
-            .into_iter()
-            .map(|m| m.text)
-            .collect()
-    }
-
     /// Find an already-open chat window whose title matches `chat_display_name`
     /// (the other party's — or your own, for the self/memo chat — display name).
     fn find_chat_window(app: &AXUIElement, chat_display_name: &str) -> Option<AXUIElement> {
@@ -647,9 +636,8 @@ mod imp {
     }
 
     /// Send `message` to the chat identified by `chat_display_name` via AX
-    /// automation, then poll the chat window's own message list (scraped via
-    /// AX, not the local SQLCipher DB) to confirm delivery instead of trusting
-    /// a fixed sleep.
+    /// automation. Returns after KakaoTalk accepts the Return key event; callers
+    /// must treat delivery as unconfirmed and avoid automatic retries.
     ///
     /// `chat_display_name` should be a substring of the chat's title as shown
     /// in the chat list (same matching convention as kakaocli's `send`).
@@ -658,18 +646,28 @@ mod imp {
         ensure_ax_permission()?;
         let app = AXUIElement::application(pid);
 
-        open_chat_row(&app, chat_display_name)?;
-        press_return(pid)?;
+        // Fast path for an already-open chat. Avoiding a full snapshot of the
+        // main chat-list window cuts tens of seconds on large chat histories
+        // and does not change the selected/folded state of that window.
+        let field = find_chat_window(&app, chat_display_name)
+            .and_then(|window| find_input_field_in(&window));
 
-        let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
-        let field = loop {
-            match find_input_field(&app, chat_display_name) {
-                Ok(field) => break field,
-                Err(e) => {
-                    if Instant::now() >= deadline {
-                        return Err(e.context("chat window did not open in time"));
+        let field = if let Some(field) = field {
+            field
+        } else {
+            open_chat_row(&app, chat_display_name)?;
+            press_return(pid)?;
+
+            let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
+            loop {
+                match find_input_field(&app, chat_display_name) {
+                    Ok(field) => break field,
+                    Err(e) => {
+                        if Instant::now() >= deadline {
+                            return Err(e.context("chat window did not open in time"));
+                        }
+                        sleep(Duration::from_millis(150));
                     }
-                    sleep(Duration::from_millis(150));
                 }
             }
         };
@@ -679,36 +677,7 @@ mod imp {
         }
         press_return(pid)?;
 
-        verify_sent(&app, message, VERIFY_TIMEOUT)
-    }
-
-    /// Poll every open chat window's AX-scraped message list for `message` to
-    /// appear, instead of a fixed sleep+assume-success. Scanning all windows
-    /// (rather than matching one by title) sidesteps the fact that a chat
-    /// window's title is the *other party's* name (or your own name, for the
-    /// self/"나와의 채팅" memo chat) — not necessarily the string used to select
-    /// the chat in the list. Needs no extra permission (no Screen Recording,
-    /// unlike a screenshot-based verification loop) since it reuses the same
-    /// Accessibility access already granted for sending.
-    fn verify_sent(app: &AXUIElement, message: &str, timeout: Duration) -> Result<()> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if let Ok(windows) = app.windows() {
-                if windows
-                    .iter()
-                    .any(|w| read_visible_message_texts(&w).iter().any(|t| t == message))
-                {
-                    return Ok(());
-                }
-            }
-            if Instant::now() >= deadline {
-                anyhow::bail!(
-                "sent the message but could not confirm it appeared in any open chat window within {}s — check KakaoTalk manually",
-                timeout.as_secs()
-            );
-            }
-            sleep(VERIFY_POLL_INTERVAL);
-        }
+        Ok(())
     }
 
     /// One chat-list row scraped from the main window, read-only (never opens
@@ -790,14 +759,8 @@ mod imp {
         use super::*;
 
         #[test]
-        fn open_chat_timeout_is_bounded_and_shorter_than_verify_timeout() {
-            assert!(OPEN_CHAT_TIMEOUT < VERIFY_TIMEOUT);
+        fn open_chat_timeout_is_bounded() {
             assert!(OPEN_CHAT_TIMEOUT.as_secs() > 0);
-        }
-
-        #[test]
-        fn verify_poll_interval_is_smaller_than_timeout() {
-            assert!(VERIFY_POLL_INTERVAL < VERIFY_TIMEOUT);
         }
 
         #[test]

--- a/src/commands/local_send.rs
+++ b/src/commands/local_send.rs
@@ -55,14 +55,19 @@ pub fn cmd_local_send(opts: LocalSendOptions) -> Result<()> {
     }
 
     ax_send::send_via_ax(chat_name, message)?;
+    eprintln!(
+        "Warning: KakaoTalk accepted the send action, but delivery is not confirmed. \
+         Check the chat before retrying to avoid duplicates."
+    );
 
     if json {
         crate::util::output_json(&serde_json::json!({
             "chat_name": chat_name,
-            "status": "sent",
+            "status": "accepted_unconfirmed",
+            "confirmed": false,
         }))?;
     } else {
-        println!("Message sent!");
+        println!("Message send action completed; delivery unconfirmed.");
     }
 
     Ok(())

--- a/src/commands/local_send.rs
+++ b/src/commands/local_send.rs
@@ -54,20 +54,17 @@ pub fn cmd_local_send(opts: LocalSendOptions) -> Result<()> {
         }
     }
 
+    // Returns Ok only after the sent text is confirmed in the target chat
+    // window's own message bubbles (scoped verify inside send_via_ax).
     ax_send::send_via_ax(chat_name, message)?;
-    eprintln!(
-        "Warning: KakaoTalk accepted the send action, but delivery is not confirmed. \
-         Check the chat before retrying to avoid duplicates."
-    );
 
     if json {
         crate::util::output_json(&serde_json::json!({
             "chat_name": chat_name,
-            "status": "accepted_unconfirmed",
-            "confirmed": false,
+            "status": "sent",
         }))?;
     } else {
-        println!("Message send action completed; delivery unconfirmed.");
+        println!("Message sent!");
     }
 
     Ok(())


### PR DESCRIPTION
Builds on @twoimo's #35. Takes the fast path (reuse an already-open chat window instead of a tens-of-seconds full chat-list snapshot), but keeps delivery verification — scoped to just the target window's bubbles, so it stays fast (~1.8s measured) and still confirms the send landed.

Drops #35's second commit (ax-watch preview-change): it re-fires on your own sends / any room activity, the noise ax-watch's unread-only design avoids. The right way to catch open-room messages is bubble diffing — left as a Tier-2 item in ROADMAP.md, under the north star (local DB tailing).

Closes #35 (superseded, credit retained).

## Test
- build / clippy -D warnings / fmt / 172 tests pass
- live: `local-send "정훈"` → "Message sent!" confirmed, 1.85s

Claude-Session: https://claude.ai/code/session_018aWcCtNEWNvdEewLQz8Fy3